### PR TITLE
Humble port mbf mesh core

### DIFF
--- a/mbf_mesh_core/CMakeLists.txt
+++ b/mbf_mesh_core/CMakeLists.txt
@@ -1,23 +1,25 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(mbf_mesh_core)
 
 
-find_package(catkin REQUIRED COMPONENTS
+find_package(ament_cmake REQUIRED)
+set(dependencies
   mbf_abstract_core
   mesh_map
 )
 
-catkin_package(
-  INCLUDE_DIRS include
-  CATKIN_DEPENDS mbf_abstract_core mesh_map
-)
+foreach(dep IN LISTS dependencies)
+  find_package(${dep} REQUIRED)
+endforeach()
 
 include_directories(
   include
-  ${catkin_INCLUDE_DIRS}
 )
 
-install(DIRECTORY include/${PROJECT_NAME}/
-  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
-  FILES_MATCHING PATTERN "*.h"
+install(DIRECTORY include/
+  DESTINATION include
 )
+
+ament_export_include_directories(include)
+ament_export_dependencies(${dependencies})
+ament_package()

--- a/mbf_mesh_core/include/mbf_mesh_core/mesh_controller.h
+++ b/mbf_mesh_core/include/mbf_mesh_core/mesh_controller.h
@@ -106,8 +106,8 @@ public:
    * @return true if the plugin has been initialized successfully
    */
   virtual bool initialize(const std::string& name,
-                          const boost::shared_ptr<tf2_ros::Buffer>& tf_ptr,
-                          const boost::shared_ptr<mesh_map::MeshMap>& mesh_map_ptr,
+                          const std::shared_ptr<tf2_ros::Buffer>& tf_ptr,
+                          const std::shared_ptr<mesh_map::MeshMap>& mesh_map_ptr,
                           const rclcpp::Node::SharedPtr& node) = 0;
 };
 } /* namespace mbf_mesh_core */

--- a/mbf_mesh_core/include/mbf_mesh_core/mesh_controller.h
+++ b/mbf_mesh_core/include/mbf_mesh_core/mesh_controller.h
@@ -105,8 +105,10 @@ public:
    * @param mesh_map_ptr A shared pointer to the mesh map
    * @return true if the plugin has been initialized successfully
    */
-  virtual bool initialize(const std::string& name, const boost::shared_ptr<tf2_ros::Buffer>& tf_ptr,
-                          const boost::shared_ptr<mesh_map::MeshMap>& mesh_map_ptr) = 0;
+  virtual bool initialize(const std::string& name,
+                          const boost::shared_ptr<tf2_ros::Buffer>& tf_ptr,
+                          const boost::shared_ptr<mesh_map::MeshMap>& mesh_map_ptr,
+                          const rclcpp::Node::SharedPtr& node) = 0;
 };
 } /* namespace mbf_mesh_core */
 

--- a/mbf_mesh_core/include/mbf_mesh_core/mesh_controller.h
+++ b/mbf_mesh_core/include/mbf_mesh_core/mesh_controller.h
@@ -37,21 +37,23 @@
 #ifndef MBF_MESH_CORE__MESH_CONTROLLER_H
 #define MBF_MESH_CORE__MESH_CONTROLLER_H
 
-#include <boost/shared_ptr.hpp>
-#include <geometry_msgs/PoseStamped.h>
-#include <geometry_msgs/TwistStamped.h>
-#include <mbf_abstract_core/abstract_controller.h>
-#include <mesh_map/mesh_map.h>
-#include <stdint.h>
+#include <memory>
 #include <string>
 #include <vector>
+
+#include <geometry_msgs/msg/pose_stamped.hpp>
+#include <geometry_msgs/msg/twist_stamped.hpp>
+#include <mbf_abstract_core/abstract_controller.h>
+#include <mesh_map/mesh_map.h>
 
 namespace mbf_mesh_core
 {
 class MeshController : public mbf_abstract_core::AbstractController
 {
 public:
-  typedef boost::shared_ptr<mbf_mesh_core::MeshController> Ptr;
+  typedef std::shared_ptr<mbf_mesh_core::MeshController> Ptr;
+
+  MeshController() = delete;
 
   /**
    * @brief Destructor
@@ -68,9 +70,9 @@ public:
    * @param message Optional more detailed outcome as a string
    * @return Result code as described on ExePath action result (see ExePath.action)
    */
-  virtual uint32_t computeVelocityCommands(const geometry_msgs::PoseStamped& pose,
-                                           const geometry_msgs::TwistStamped& velocity,
-                                           geometry_msgs::TwistStamped& cmd_vel, std::string& message) = 0;
+  virtual uint32_t computeVelocityCommands(const geometry_msgs::msg::PoseStamped& pose,
+                                           const geometry_msgs::msg::TwistStamped& velocity,
+                                           geometry_msgs::msg::TwistStamped& cmd_vel, std::string& message) = 0;
 
   /**
    * @brief Check if the goal pose has been achieved by the local planner
@@ -87,7 +89,7 @@ public:
    * @param plan The plan to pass to the local planner
    * @return True if the plan was updated successfully, false otherwise
    */
-  virtual bool setPlan(const std::vector<geometry_msgs::PoseStamped>& plan) = 0;
+  virtual bool setPlan(const std::vector<geometry_msgs::msg::PoseStamped>& plan) = 0;
 
   /**
    * @brief Requests the planner to cancel, e.g. if it takes too much time.
@@ -105,12 +107,6 @@ public:
    */
   virtual bool initialize(const std::string& name, const boost::shared_ptr<tf2_ros::Buffer>& tf_ptr,
                           const boost::shared_ptr<mesh_map::MeshMap>& mesh_map_ptr) = 0;
-
-protected:
-  /**
-   * @brief Constructor
-   */
-  MeshController(){};
 };
 } /* namespace mbf_mesh_core */
 

--- a/mbf_mesh_core/include/mbf_mesh_core/mesh_planner.h
+++ b/mbf_mesh_core/include/mbf_mesh_core/mesh_planner.h
@@ -37,20 +37,22 @@
 #ifndef MBF_MESH_CORE__MESH_PLANNER_H
 #define MBF_MESH_CORE__MESH_PLANNER_H
 
-#include <boost/shared_ptr.hpp>
-#include <geometry_msgs/PoseStamped.h>
+#include <string>
+#include <memory>
+#include <vector>
+
+#include <geometry_msgs/msg/pose_stamped.hpp>
 #include <mbf_abstract_core/abstract_planner.h>
 #include <mesh_map/mesh_map.h>
-#include <stdint.h>
-#include <string>
-#include <vector>
 
 namespace mbf_mesh_core
 {
 class MeshPlanner : public mbf_abstract_core::AbstractPlanner
 {
 public:
-  typedef boost::shared_ptr<mbf_mesh_core::MeshPlanner> Ptr;
+  typedef std::shared_ptr<mbf_mesh_core::MeshPlanner> Ptr;
+
+  MeshPlanner() = delete;
 
   /**
    * @brief Destructor
@@ -68,8 +70,8 @@ public:
    * @param message Optional more detailed outcome as a string
    * @return Result code as described on GetPath action result. (see GetPath.action)
    */
-  virtual uint32_t makePlan(const geometry_msgs::PoseStamped& start, const geometry_msgs::PoseStamped& goal,
-                            double tolerance, std::vector<geometry_msgs::PoseStamped>& plan, double& cost,
+  virtual uint32_t makePlan(const geometry_msgs::msg::PoseStamped& start, const geometry_msgs::PoseStamped& goal,
+                            double tolerance, std::vector<geometry_msgs::msg::PoseStamped>& plan, double& cost,
                             std::string& message) = 0;
 
   /**
@@ -86,12 +88,6 @@ public:
    * @return true if the plugin has been initialized successfully
    */
   virtual bool initialize(const std::string& name, const boost::shared_ptr<mesh_map::MeshMap>& mesh_map_ptr) = 0;
-
-protected:
-  /**
-   * @brief Constructor
-   */
-  MeshPlanner(){};
 };
 } /* namespace mbf_mesh_core */
 

--- a/mbf_mesh_core/include/mbf_mesh_core/mesh_planner.h
+++ b/mbf_mesh_core/include/mbf_mesh_core/mesh_planner.h
@@ -87,7 +87,7 @@ public:
    * @param mesh_map_ptr A shared pointer to the mesh map instance to access attributes and helper functions, etc.
    * @return true if the plugin has been initialized successfully
    */
-  virtual bool initialize(const std::string& name, const boost::shared_ptr<mesh_map::MeshMap>& mesh_map_ptr, const rclcpp::Node::SharedPtr& node) = 0;
+  virtual bool initialize(const std::string& name, const std::shared_ptr<mesh_map::MeshMap>& mesh_map_ptr, const rclcpp::Node::SharedPtr& node) = 0;
 };
 } /* namespace mbf_mesh_core */
 

--- a/mbf_mesh_core/include/mbf_mesh_core/mesh_planner.h
+++ b/mbf_mesh_core/include/mbf_mesh_core/mesh_planner.h
@@ -87,7 +87,7 @@ public:
    * @param mesh_map_ptr A shared pointer to the mesh map instance to access attributes and helper functions, etc.
    * @return true if the plugin has been initialized successfully
    */
-  virtual bool initialize(const std::string& name, const boost::shared_ptr<mesh_map::MeshMap>& mesh_map_ptr) = 0;
+  virtual bool initialize(const std::string& name, const boost::shared_ptr<mesh_map::MeshMap>& mesh_map_ptr, const rclcpp::Node::SharedPtr& node) = 0;
 };
 } /* namespace mbf_mesh_core */
 

--- a/mbf_mesh_core/include/mbf_mesh_core/mesh_recovery.h
+++ b/mbf_mesh_core/include/mbf_mesh_core/mesh_recovery.h
@@ -37,11 +37,11 @@
 #ifndef MBF_MESH_CORE__ABSTRACT_RECOVERY_H
 #define MBF_MESH_CORE__ABSTRACT_RECOVERY_H
 
-#include <boost/shared_ptr.hpp>
+#include <string>
+#include <memory>
+
 #include <mbf_abstract_core/abstract_recovery.h>
 #include <mesh_map/mesh_map.h>
-#include <stdint.h>
-#include <string>
 
 namespace mbf_mesh_core
 {
@@ -54,7 +54,7 @@ namespace mbf_mesh_core
 class MeshRecovery : public mbf_abstract_core::AbstractRecovery
 {
 public:
-  typedef boost::shared_ptr<::mbf_mesh_core::MeshRecovery> Ptr;
+  typedef std::shared_ptr<::mbf_mesh_core::MeshRecovery> Ptr;
 
   /**
    * @brief Runs the AbstractRecovery
@@ -63,6 +63,9 @@ public:
    * @return An outcome which will be hand over to the action result.
    */
   virtual uint32_t runBehavior(std::string& message) = 0;
+
+  //! MeshRecovery cannot be constructed
+  MeshRecovery() = delete;
 
   /**
    * @brief Virtual destructor for the interface
@@ -89,11 +92,6 @@ public:
   virtual bool initialize(const std::string& name, const boost::shared_ptr<tf2_ros::Buffer>& tf_ptr,
                           const boost::shared_ptr<mesh_map::MeshMap>& mesh_map_ptr) = 0;
 
-protected:
-  /**
-   * @brief Constructor
-   */
-  MeshRecovery(){};
 };
 }; /* namespace mbf_mesh_core */
 

--- a/mbf_mesh_core/include/mbf_mesh_core/mesh_recovery.h
+++ b/mbf_mesh_core/include/mbf_mesh_core/mesh_recovery.h
@@ -88,8 +88,8 @@ public:
    * @param mesh_map_ptr A shared pointer to the mesh map
    * @return true if the plugin has been initialized successfully
    */
-  virtual bool initialize(const std::string& name, const boost::shared_ptr<tf2_ros::Buffer>& tf_ptr,
-                          const boost::shared_ptr<mesh_map::MeshMap>& mesh_map_ptr,
+  virtual bool initialize(const std::string& name, const std::shared_ptr<tf2_ros::Buffer>& tf_ptr,
+                          const std::shared_ptr<mesh_map::MeshMap>& mesh_map_ptr,
                           const rclcpp::Node::SharedPtr& node) = 0;
 
 };

--- a/mbf_mesh_core/include/mbf_mesh_core/mesh_recovery.h
+++ b/mbf_mesh_core/include/mbf_mesh_core/mesh_recovery.h
@@ -64,7 +64,6 @@ public:
    */
   virtual uint32_t runBehavior(std::string& message) = 0;
 
-  //! MeshRecovery cannot be constructed
   MeshRecovery() = delete;
 
   /**
@@ -90,7 +89,8 @@ public:
    * @return true if the plugin has been initialized successfully
    */
   virtual bool initialize(const std::string& name, const boost::shared_ptr<tf2_ros::Buffer>& tf_ptr,
-                          const boost::shared_ptr<mesh_map::MeshMap>& mesh_map_ptr) = 0;
+                          const boost::shared_ptr<mesh_map::MeshMap>& mesh_map_ptr,
+                          const rclcpp::Node::SharedPtr& node) = 0;
 
 };
 }; /* namespace mbf_mesh_core */

--- a/mbf_mesh_core/package.xml
+++ b/mbf_mesh_core/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package format="2">
+<package format="3">
     <name>mbf_mesh_core</name>
     <version>1.0.1</version>
     <description>The mbf_mesh_core package</description>
@@ -9,9 +9,10 @@
     <license>BSD-3</license>
     <author email="spuetz@uos.de">Sebastian Pütz</author>
 
-    <buildtool_depend>catkin</buildtool_depend>
-
     <depend>mbf_abstract_core</depend>
     <depend>mesh_map</depend>
 
+    <export>
+      <build_type>ament_cmake</build_type>
+    </export>
 </package>


### PR DESCRIPTION
This PR ports `mbf_mesh_core` for ROS2 humble.

It also adapts the interface of the abstract classes to transmit a node ptr, so the plugins can use ROS params, logging, etc.