### PR TITLE
Add support for simple_core plugins to mesh navigation server

### DIFF
--- a/mbf_mesh_nav/CMakeLists.txt
+++ b/mbf_mesh_nav/CMakeLists.txt
@@ -10,6 +10,7 @@ set(dependencies
   geometry_msgs
   LVR2
   mbf_abstract_nav
+  mbf_simple_core
   mbf_mesh_core
   mbf_msgs
   mesh_map

--- a/mbf_mesh_nav/CMakeLists.txt
+++ b/mbf_mesh_nav/CMakeLists.txt
@@ -54,10 +54,13 @@ install(DIRECTORY include/
   DESTINATION include
 )
 
-install(TARGETS ${PROJECT_NAME} mbf_mesh_server
+install(TARGETS mbf_mesh_server
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib
   RUNTIME DESTINATION bin
+)
+install(TARGETS ${PROJECT_NAME}
+  DESTINATION lib/${PROJECT_NAME}
 )
 
 ament_export_include_directories(include)

--- a/mbf_mesh_nav/include/mbf_mesh_nav/mesh_navigation_server.h
+++ b/mbf_mesh_nav/include/mbf_mesh_nav/mesh_navigation_server.h
@@ -51,6 +51,10 @@
 #include <std_srvs/srv/empty.hpp>
 #include <rclcpp/rclcpp.hpp>
 
+#include <mbf_simple_core/simple_planner.h>
+#include <mbf_simple_core/simple_controller.h>
+#include <mbf_simple_core/simple_recovery.h>
+
 #include <pluginlib/class_loader.hpp>
 
 namespace mbf_mesh_nav
@@ -66,6 +70,8 @@ namespace mbf_mesh_nav
  * nav_core/BaseLocalPlanner, nav_core/BaseMeshPlanner and the
  *        nav_core/RecoveryBehavior base classes as plugin interfaces. These
  * plugin interface are the same for the old move_base
+ *
+ * Supports both mesh_core and simple_core plugins.
  *
  * @ingroup navigation_server move_base_server
  */
@@ -186,12 +192,15 @@ private:
 
   //! plugin class loader for recovery behaviors plugins
   pluginlib::ClassLoader<mbf_mesh_core::MeshRecovery> recovery_plugin_loader_;
+  pluginlib::ClassLoader<mbf_simple_core::SimpleRecovery> simple_recovery_plugin_loader_;
 
   //! plugin class loader for controller plugins
   pluginlib::ClassLoader<mbf_mesh_core::MeshController> controller_plugin_loader_;
+  pluginlib::ClassLoader<mbf_simple_core::SimpleController> simple_controller_plugin_loader_;
 
   //! plugin class loader for planner plugins
   pluginlib::ClassLoader<mbf_mesh_core::MeshPlanner> planner_plugin_loader_;
+  pluginlib::ClassLoader<mbf_simple_core::SimplePlanner> simple_planner_plugin_loader_;
 
   //! Shared pointer to the common global mesh
   MeshPtr mesh_ptr_;

--- a/mbf_mesh_nav/package.xml
+++ b/mbf_mesh_nav/package.xml
@@ -11,6 +11,7 @@
 
     <depend>geometry_msgs</depend>
     <depend>mbf_abstract_nav</depend>
+    <depend>mbf_simple_core</depend>
     <depend>mbf_mesh_core</depend>
     <depend>mbf_msgs</depend>
     <depend>mesh_map</depend>

--- a/mbf_mesh_nav/src/mesh_navigation_server.cpp
+++ b/mbf_mesh_nav/src/mesh_navigation_server.cpp
@@ -272,7 +272,6 @@ bool MeshNavigationServer::initializeRecoveryPlugin(const std::string& name,
     return false;
   }
 
-  /////////////////
   mbf_mesh_core::MeshRecovery::Ptr mesh_behavior_ptr =
       std::dynamic_pointer_cast<mbf_mesh_core::MeshRecovery>(behavior_ptr);
   if (mesh_behavior_ptr) 

--- a/mbf_mesh_nav/src/mesh_navigation_server.cpp
+++ b/mbf_mesh_nav/src/mesh_navigation_server.cpp
@@ -109,7 +109,7 @@ typename AbstractThing::Ptr loadPlugin(const std::string& thing_type, pluginlib:
   else
   {
     // thing was not found
-    RCLCPP_ERROR_STREAM(logger, "Failed to find the " << thing_type << " thing. "
+    RCLCPP_ERROR_STREAM(logger, "Failed to find the " << thing_type << " " << which_thing << ". "
                                 << "Are you sure it's properly registered and that the containing library is built? "
                                 << "Registered mesh " << which_thing << " are: " << stringVectorToString(available_mesh_things)
                                 << ". Registered simple " << which_thing << " are: " << stringVectorToString(available_simple_things));

--- a/mesh_map/src/mesh_map.cpp
+++ b/mesh_map/src/mesh_map.cpp
@@ -1236,7 +1236,7 @@ void MeshMap::publishVertexColors()
 
 rcl_interfaces::msg::SetParametersResult MeshMap::reconfigureCallback(std::vector<rclcpp::Parameter> parameters)
 {
-  RCLCPP_INFO_STREAM(node->get_logger(), "Set parameters callback...");
+  RCLCPP_DEBUG_STREAM(node->get_logger(), "Set parameters callback...");
   rcl_interfaces::msg::SetParametersResult result;
   result.successful = true;
 


### PR DESCRIPTION
This PR mainly adds support for loading both `mesh_core` and `simple_core` move base flex plugins to the mesh navigation server.

It also includes additional minor fixes:
* fixes installation of executable
* change log level for less spam