### PR TITLE
Fix/get containing face and error message passing

### DIFF
--- a/cvp_mesh_planner/include/cvp_mesh_planner/cvp_mesh_planner.h
+++ b/cvp_mesh_planner/include/cvp_mesh_planner/cvp_mesh_planner.h
@@ -96,10 +96,12 @@ protected:
    * @param start The seed of the wave, i.e. the robot's goal pose
    * @param goal The goal of the wavefront, where it will stop propagating
    * @param path The backtracked path
+   * @param message String with additional information wrt. the outcome. Will be transmitted to the action caller.
    * @return a ExePath action related outcome code
    */
   uint32_t waveFrontPropagation(const mesh_map::Vector& start, const mesh_map::Vector& goal,
-                                std::list<std::pair<mesh_map::Vector, lvr2::FaceHandle>>& path);
+                                std::list<std::pair<mesh_map::Vector, lvr2::FaceHandle>>& path,
+                                std::string& message);
 
   /**
    *
@@ -109,13 +111,14 @@ protected:
    * @param edge_weights The edge weights map to use for vertex distances in a triangle
    * @param costs The combined vertex costs to use during the propagation
    * @param path The backtracked path
+   * @param message String with additional information wrt. the outcome. Will be transmitted to the action caller.
    * @param distances The computed distances
    * @param predecessors The backtracked predecessors
    * @return a ExePath action related outcome code
    */
   uint32_t waveFrontPropagation(const mesh_map::Vector& start, const mesh_map::Vector& goal,
                                 const lvr2::DenseEdgeMap<float>& edge_weights, const lvr2::DenseVertexMap<float>& costs,
-                                std::list<std::pair<mesh_map::Vector, lvr2::FaceHandle>>& path,
+                                std::list<std::pair<mesh_map::Vector, lvr2::FaceHandle>>& path, std::string& message,
                                 lvr2::DenseVertexMap<float>& distances,
                                 lvr2::DenseVertexMap<lvr2::VertexHandle>& predecessors);
 

--- a/cvp_mesh_planner/src/cvp_mesh_planner.cpp
+++ b/cvp_mesh_planner/src/cvp_mesh_planner.cpp
@@ -85,7 +85,7 @@ uint32_t CVPMeshPlanner::makePlan(const geometry_msgs::msg::PoseStamped& start,
 
   cost = 0;
   float dir_length;
-  if (!path.empty())
+  if (!cancel_planning_ && !path.empty())
   {
     mesh_map::Vector vec = path.front().first;
     lvr2::FaceHandle fH = path.front().second;

--- a/mesh_map/src/mesh_map.cpp
+++ b/mesh_map/src/mesh_map.cpp
@@ -1042,41 +1042,41 @@ lvr2::OptionalFaceHandle MeshMap::getContainingFace(Vector& position, const floa
 
 boost::optional<std::tuple<lvr2::FaceHandle, std::array<mesh_map::Vector , 3>,
     std::array<float, 3>>> MeshMap::searchContainingFace(
-    Vector& position, const float& max_dist)
+    Vector& query_point, const float& max_dist)
 {
-  if(auto vH_opt = getNearestVertexHandle(position))
+  if(auto vH_opt = getNearestVertexHandle(query_point))
   {
     auto vH = vH_opt.unwrap();
-    float min_triangle_position_distance = std::numeric_limits<float>::max();
-    std::array<Vector, 3> vertices;
-    std::array<float, 3> bary_coords;
-    lvr2::OptionalFaceHandle opt_fH;
-    for(auto fH : mesh_ptr->getFacesOfVertex(vH))
+    float lowest_distance_found = std::numeric_limits<float>::max();
+    std::array<Vector, 3> closest_face_vertices;
+    std::array<float, 3> bary_coords_on_closest_face;
+    lvr2::OptionalFaceHandle opt_closest_face_handle;
+    for(auto current_face_handle : mesh_ptr->getFacesOfVertex(vH))
     {
-      const auto& tmp_vertices = mesh_ptr->getVertexPositionsOfFace(fH);
-      float dist = 0;
-      std::array<float, 3> tmp_bary_coords;
-      if (mesh_map::projectedBarycentricCoords(position, tmp_vertices, tmp_bary_coords, dist)
-          && std::fabs(dist) < max_dist)
+      const auto& current_vertices = mesh_ptr->getVertexPositionsOfFace(current_face_handle);
+      float distance_to_current_face = 0;
+      std::array<float, 3> current_bary_coords;
+      if (mesh_map::projectedBarycentricCoords(query_point, current_vertices, current_bary_coords, distance_to_face)
+          && std::fabs(distance_to_face) < max_dist)
       {
-        return std::make_tuple(fH, tmp_vertices, tmp_bary_coords);
+        return std::make_tuple(current_face_handle, current_vertices, current_bary_coords);
       }
 
       float triangle_dist = 0;
-      triangle_dist += (tmp_vertices[0] - position).length2();
-      triangle_dist += (tmp_vertices[1] - position).length2();
-      triangle_dist += (tmp_vertices[2] - position).length2();
-      if(triangle_dist < min_triangle_position_distance)
+      triangle_dist += (current_vertices[0] - query_point).length2();
+      triangle_dist += (current_vertices[1] - query_point).length2();
+      triangle_dist += (current_vertices[2] - query_point).length2();
+      if(triangle_dist < lowest_distance_found)
       {
-        min_triangle_position_distance = triangle_dist;
-        opt_fH = fH;
-        vertices = tmp_vertices;
-        bary_coords = tmp_bary_coords;
+        lowest_distance_found = triangle_dist;
+        opt_closest_face_handle = current_face_handle;
+        closest_face_vertices = current_vertices;
+        bary_coords_on_closest_face = current_bary_coords;
       }
     }
-    if(opt_fH)
+    if(opt_closest_face_handle)
     {
-      return std::make_tuple(opt_fH.unwrap(), vertices, bary_coords);
+      return std::make_tuple(opt_closest_face_handle.unwrap(), closest_face_vertices, bary_coords_on_closest_face);
     }
     RCLCPP_ERROR_STREAM(node->get_logger(), "No containing face found!");
     return boost::none;

--- a/mesh_map/src/mesh_map.cpp
+++ b/mesh_map/src/mesh_map.cpp
@@ -1056,16 +1056,16 @@ boost::optional<std::tuple<lvr2::FaceHandle, std::array<mesh_map::Vector , 3>,
       const auto& tmp_vertices = mesh_ptr->getVertexPositionsOfFace(fH);
       float dist = 0;
       std::array<float, 3> tmp_bary_coords;
-      if (mesh_map::projectedBarycentricCoords(position, vertices, tmp_bary_coords, dist)
+      if (mesh_map::projectedBarycentricCoords(position, tmp_vertices, tmp_bary_coords, dist)
           && std::fabs(dist) < max_dist)
       {
         return std::make_tuple(fH, tmp_vertices, tmp_bary_coords);
       }
 
       float triangle_dist = 0;
-      triangle_dist += (vertices[0] - position).length2();
-      triangle_dist += (vertices[1] - position).length2();
-      triangle_dist += (vertices[2] - position).length2();
+      triangle_dist += (tmp_vertices[0] - position).length2();
+      triangle_dist += (tmp_vertices[1] - position).length2();
+      triangle_dist += (tmp_vertices[2] - position).length2();
       if(triangle_dist < min_triangle_position_distance)
       {
         min_triangle_position_distance = triangle_dist;

--- a/mesh_map/src/mesh_map.cpp
+++ b/mesh_map/src/mesh_map.cpp
@@ -1056,19 +1056,11 @@ boost::optional<std::tuple<lvr2::FaceHandle, std::array<mesh_map::Vector , 3>,
       const auto& current_vertices = mesh_ptr->getVertexPositionsOfFace(current_face_handle);
       float distance_to_current_face = 0;
       std::array<float, 3> current_bary_coords;
-      if (mesh_map::projectedBarycentricCoords(query_point, current_vertices, current_bary_coords, distance_to_face)
-          && std::fabs(distance_to_face) < max_dist)
-      {
-        return std::make_tuple(current_face_handle, current_vertices, current_bary_coords);
-      }
+      const bool is_query_point_in_current_face = mesh_map::projectedBarycentricCoords(query_point, current_vertices, current_bary_coords, distance_to_current_face);
 
-      float triangle_dist = 0;
-      triangle_dist += (current_vertices[0] - query_point).length2();
-      triangle_dist += (current_vertices[1] - query_point).length2();
-      triangle_dist += (current_vertices[2] - query_point).length2();
-      if(triangle_dist < lowest_distance_found)
+      if(is_query_point_in_current_face && distance_to_current_face < lowest_distance_found)
       {
-        lowest_distance_found = triangle_dist;
+        lowest_distance_found = distance_to_current_face;
         opt_closest_face_handle = current_face_handle;
         closest_face_vertices = current_vertices;
         bary_coords_on_closest_face = current_bary_coords;


### PR DESCRIPTION
# PR Changes
This PR introduces two fixes for the cvp mesh planner
* Get the correct the start and goal vertices.
* Return more quickly when canceled.
See the comments in the code for more information.

In addition, the PR
* adapts few internal interfaces to allow for passing a message string through to the action caller.

# What works now
With this PR, I get a valid path when I drive from one of the floor triangles to the other one.
![valid_path](https://github.com/naturerobots/mesh_navigation/assets/727012/40c298f7-ac22-47e5-ac39-8a77ea8e3974)

# Up next (in another PR):
* fix when start and goal triangles are the same (currently, this yields an empty path) 
![invalid_path_start_goal_triangle_equal](https://github.com/naturerobots/mesh_navigation/assets/727012/86c29f2f-9584-4b20-adf9-d811fb15e2fe)
* fix planning when goal is on the wall
  * currently, this leads to an endless loop that gets broken via planner patience