### PR TITLE
compilation for humble and ubuntu20

### DIFF
--- a/cvp_mesh_planner/CMakeLists.txt
+++ b/cvp_mesh_planner/CMakeLists.txt
@@ -7,15 +7,21 @@ find_package(mbf_msgs REQUIRED)
 find_package(mbf_utility REQUIRED)
 find_package(mesh_map REQUIRED)
 find_package(rclcpp REQUIRED)
+find_package(LVR2 REQUIRED)
 
 pluginlib_export_plugin_description_file(mbf_mesh_core cvp_mesh_planner.xml)
 
 add_library(${PROJECT_NAME} src/cvp_mesh_planner.cpp)
 target_include_directories(${PROJECT_NAME} PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-  $<INSTALL_INTERFACE:include>)
+  $<INSTALL_INTERFACE:include>
+  ${LVR2_INCLUDE_DIRS})
 target_compile_definitions(${PROJECT_NAME} PRIVATE "CVP_MESH_PLANNER_BUILDING_LIBRARY")
 ament_target_dependencies(${PROJECT_NAME} mbf_mesh_core mbf_msgs mbf_utility mesh_map rclcpp)
+target_link_libraries(${PROJECT_NAME} 
+    ${LVR2_LIBRARIES}
+    ${MPI_CXX_LIBRARIES}
+)
 
 install(DIRECTORY include DESTINATION include)
 install(TARGETS ${PROJECT_NAME}

--- a/dijkstra_mesh_planner/CMakeLists.txt
+++ b/dijkstra_mesh_planner/CMakeLists.txt
@@ -7,6 +7,7 @@ find_package(mbf_msgs REQUIRED)
 find_package(mbf_utility REQUIRED)
 find_package(mesh_map REQUIRED)
 find_package(rclcpp REQUIRED)
+find_package(LVR2 REQUIRED)
 
 pluginlib_export_plugin_description_file(mbf_mesh_core dijkstra_mesh_planner.xml)
 
@@ -15,9 +16,14 @@ add_library(${PROJECT_NAME}
 )
 target_include_directories(${PROJECT_NAME} PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-  $<INSTALL_INTERFACE:include>)
+  $<INSTALL_INTERFACE:include>
+  ${LVR2_INCLUDE_DIRS})
 target_compile_definitions(${PROJECT_NAME} PRIVATE "DIJKSTRA_MESH_PLANNER_BUILDING_LIBRARY")
 ament_target_dependencies(${PROJECT_NAME} mbf_mesh_core mbf_msgs mbf_utility mesh_map rclcpp)
+target_link_libraries(${PROJECT_NAME} 
+    ${LVR2_LIBRARIES}
+    ${MPI_CXX_LIBRARIES}
+)
 
 install(DIRECTORY include/
  DESTINATION include

--- a/mbf_mesh_nav/CMakeLists.txt
+++ b/mbf_mesh_nav/CMakeLists.txt
@@ -6,9 +6,9 @@ if(NOT CMAKE_CXX_STANDARD)
 endif()
 
 find_package(ament_cmake_ros REQUIRED)
+# ROS deps
 set(dependencies
   geometry_msgs
-  LVR2
   mbf_abstract_nav
   mbf_simple_core
   mbf_mesh_core
@@ -27,6 +27,8 @@ include_directories(
   include
 )
 
+find_package(LVR2 REQUIRED)
+find_package(MPI)
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(JSONCPP jsoncpp)
 
@@ -40,13 +42,26 @@ add_library(mbf_mesh_server
   src/mesh_planner_execution.cpp
   src/mesh_recovery_execution.cpp
 )
+target_include_directories(mbf_mesh_server PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+  ${LVR2_INCLUDE_DIRS})
 ament_target_dependencies(mbf_mesh_server ${dependencies})
-target_link_libraries(mbf_mesh_server ${JSONCPP_LIBRARIES})
+target_link_libraries(mbf_mesh_server 
+  ${JSONCPP_LIBRARIES}
+  ${LVR2_LIBRARIES}
+  ${MPI_CXX_LIBRARIES}
+)
 
 add_executable(${PROJECT_NAME} src/mbf_mesh_nav.cpp)
 ament_target_dependencies(${PROJECT_NAME} ${dependencies} ${${PROJECT_NAME}_EXPORTED_TARGETS})
-target_link_libraries(${PROJECT_NAME} mbf_mesh_server)
+target_include_directories(${PROJECT_NAME} PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+  ${LVR2_INCLUDE_DIRS})
 target_link_libraries(${PROJECT_NAME}
+  ${LVR2_LIBRARIES}
+  ${MPI_CXX_LIBRARIES}
   ${JSONCPP_LIBRARIES}
   mbf_mesh_server
 )

--- a/mesh_client/CMakeLists.txt
+++ b/mesh_client/CMakeLists.txt
@@ -6,15 +6,11 @@ if(NOT CMAKE_CXX_STANDARD)
 endif()
 
 find_package(ament_cmake_ros REQUIRED)
-set(dependencies
-  rclcpp
-  LVR2
-  CURL
-  Eigen3
-)
-foreach(dep IN LISTS dependencies)
-  find_package(${dep} REQUIRED)
-endforeach()
+find_package(rclcpp REQUIRED)
+find_package(LVR2 REQUIRED)
+find_package(MPI)
+find_package(Eigen3 3.3 REQUIRED NO_MODULE)
+find_package(CURL REQUIRED)
 
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(JSONCPP jsoncpp)
@@ -26,8 +22,18 @@ include_directories(
 add_library(${PROJECT_NAME}
   src/mesh_client.cpp
 )
-ament_target_dependencies(${PROJECT_NAME} ${dependencies})
-target_link_libraries(${PROJECT_NAME} jsoncpp)
+target_include_directories(${PROJECT_NAME} PUBLIC
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<INSTALL_INTERFACE:include>"
+  ${LVR2_INCLUDE_DIRS})
+ament_target_dependencies(${PROJECT_NAME} 
+    rclcpp)
+target_link_libraries(${PROJECT_NAME} 
+    jsoncpp 
+    Eigen3::Eigen
+    ${LVR2_LIBRARIES}
+    ${MPI_CXX_LIBRARIES}
+)
 
 install(DIRECTORY include/
   DESTINATION include

--- a/mesh_controller/CMakeLists.txt
+++ b/mesh_controller/CMakeLists.txt
@@ -9,6 +9,8 @@ find_package(mbf_utility REQUIRED)
 find_package(mesh_map REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
+find_package(LVR2 REQUIRED)
+find_package(MPI)
 
 
 pluginlib_export_plugin_description_file(mbf_mesh_core mesh_controller.xml)
@@ -16,9 +18,14 @@ pluginlib_export_plugin_description_file(mbf_mesh_core mesh_controller.xml)
 add_library(${PROJECT_NAME} src/mesh_controller.cpp)
 target_include_directories(${PROJECT_NAME} PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-  $<INSTALL_INTERFACE:include>)
+  $<INSTALL_INTERFACE:include>
+  ${LVR2_INCLUDE_DIRS})
 target_compile_definitions(${PROJECT_NAME} PRIVATE "MESH_CONTROLLER_BUILDING_LIBRARY")
 ament_target_dependencies(${PROJECT_NAME} example_interfaces mbf_mesh_core mbf_msgs mbf_utility mesh_map rclcpp tf2_geometry_msgs)
+target_link_libraries(${PROJECT_NAME} 
+    ${LVR2_LIBRARIES}
+    ${MPI_CXX_LIBRARIES}
+)
 
 install(DIRECTORY include DESTINATION include)
 install(TARGETS ${PROJECT_NAME}

--- a/mesh_map/CMakeLists.txt
+++ b/mesh_map/CMakeLists.txt
@@ -2,9 +2,9 @@ cmake_minimum_required(VERSION 3.5)
 project(mesh_map)
 
 find_package(ament_cmake_ros REQUIRED)
+# ROS Deps
 set(dependencies
   geometry_msgs
-  LVR2
   mesh_client
   mesh_msgs_conversions
   pluginlib
@@ -18,7 +18,10 @@ foreach(dep IN LISTS dependencies)
   find_package(${dep} REQUIRED)
 endforeach()
 
-find_package(Boost REQUIRED COMPONENTS system)
+find_package(LVR2 REQUIRED)
+find_package(MPI)
+# this is nowhere used
+# find_package(Boost REQUIRED COMPONENTS system) 
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(JSONCPP jsoncpp)
 
@@ -30,7 +33,15 @@ add_library(${PROJECT_NAME}
   src/mesh_map.cpp
   src/util.cpp
 )
+target_include_directories(${PROJECT_NAME} PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+  ${LVR2_INCLUDE_DIRS})
 ament_target_dependencies(${PROJECT_NAME} ${dependencies})
+target_link_libraries(${PROJECT_NAME} 
+    ${LVR2_LIBRARIES}
+    ${MPI_CXX_LIBRARIES}
+)
 
 install(DIRECTORY include/
   DESTINATION include

--- a/mesh_map/test/layer_plugin.cpp
+++ b/mesh_map/test/layer_plugin.cpp
@@ -14,7 +14,7 @@ class TestLayer : public mesh_map::AbstractLayer {
     return std::numeric_limits<float>::infinity();
   }
 
-  virtual bool computeLayer() override{};
+  virtual bool computeLayer() override{ return true; };
 
   virtual lvr2::VertexMap<float> &costs() override { return test_costs_; };
 


### PR DESCRIPTION
I was not able to compile mesh navigation (humble version) on my ubuntu 20. I fixed it by changing the lvr2 imports in the CMakeLists.txts like I did for the [mesh_tools](https://github.com/naturerobots/mesh_tools).

More info about my setup:
- I compiled ROS2 humble from source 
- lvr2 - current main branch (develop). Put into the "src" folder of my humble workspace
- cmake version 3.16.3

I want to check if it is still compiling with ubuntu 22 before merging this PR.