### PR TITLE
Border Layer

### DIFF
--- a/mesh_layers/CMakeLists.txt
+++ b/mesh_layers/CMakeLists.txt
@@ -8,6 +8,7 @@ find_package(LVR2)
 pluginlib_export_plugin_description_file(mesh_map mesh_layers.xml)
 
 add_library(${PROJECT_NAME}
+  src/border_layer.cpp
   src/roughness_layer.cpp
   src/height_diff_layer.cpp
   src/inflation_layer.cpp

--- a/mesh_layers/include/mesh_layers/border_layer.h
+++ b/mesh_layers/include/mesh_layers/border_layer.h
@@ -1,0 +1,148 @@
+/*
+ *  Copyright 2024, Alexander Mock
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *  2. Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *
+ *  3. Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ *  authors:
+ *    Alexander Mock <amock@uos.de>
+ *
+ */
+
+#ifndef MESH_MAP__BORDER_LAYER_H
+#define MESH_MAP__BORDER_LAYER_H
+
+#include <mesh_map/abstract_layer.h>
+#include <rclcpp/rclcpp.hpp>
+
+namespace mesh_layers
+{
+/**
+ * @brief Costmap layer which calculates the border costs to avoid mesh borders
+ */
+class BorderLayer : public mesh_map::AbstractLayer
+{
+  /**
+   * @brief try read layer from map file
+   *
+   * @return true if successul; else false
+   */
+  virtual bool readLayer() override;
+
+  /**
+   * @brief try to write layer to map file
+   *
+   * @return true if successfull; else false
+   */
+  virtual bool writeLayer() override;
+
+  /**
+   * @brief delivers the default layer value
+   *
+   * @return default value used for this layer
+   */
+  virtual float defaultValue() override
+  {
+    return std::numeric_limits<float>::infinity();
+  }
+
+  /**
+   * @brief delivers the threshold above which vertices are marked lethal
+   *
+   * @return lethal threshold
+   */
+  virtual float threshold() override;
+
+  /**
+   * @brief calculate the values of this layer
+   *
+   * @return true if successfull; else false
+   */
+  virtual bool computeLayer() override;
+
+  /**
+   * @brief mark vertices with values above the threshold as lethal
+   *
+   * @return true if successfull; else false
+   */
+  bool computeLethals();
+
+  /**
+   * @brief deliver the current costmap
+   *
+   * @return calculated costmap
+   */
+  virtual lvr2::VertexMap<float>& costs() override;
+
+  /**
+   * @brief deliver set containing all vertices marked as lethal
+   *
+   * @return lethal vertices
+   */
+  virtual std::set<lvr2::VertexHandle>& lethals() override
+  {
+    return lethal_vertices_;
+  }
+
+  /**
+   * @brief update set of lethal vertices by adding and removing vertices
+   *
+   * @param added_lethal vertices to be marked as lethal
+   * @param removed_lethal vertices to be removed from the set of lethal vertices
+   */
+  virtual void updateLethal(std::set<lvr2::VertexHandle>& added_lethal, std::set<lvr2::VertexHandle>& removed_lethal) override {};
+
+  /**
+   * @brief initializes this layer plugin
+   *
+   * @return true if initialization was successfull; else false
+   */
+  virtual bool initialize() override;
+
+  /**
+   * @brief callback for incoming param changes
+   */
+  rcl_interfaces::msg::SetParametersResult reconfigureCallback(std::vector<rclcpp::Parameter> parameters);
+
+  // latest costmap
+  lvr2::DenseVertexMap<float> border_costs_;
+  // set of all current lethal vertices
+  std::set<lvr2::VertexHandle> lethal_vertices_;
+
+  rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr dyn_params_handler_;
+  struct {
+    double threshold = 0.5;
+    double border_cost = 1.0;
+    double factor = 1.0;
+  } config_;
+};
+
+} /* namespace mesh_layers */
+
+#endif  // MESH_MAP__BORDER_LAYER_H

--- a/mesh_layers/mesh_layers.xml
+++ b/mesh_layers/mesh_layers.xml
@@ -1,4 +1,11 @@
 <library path="mesh_layers">
+    <class name="mesh_layers/BorderLayer"
+            type="mesh_layers::BorderLayer"
+            base_class_type="mesh_map::AbstractLayer">
+        <description>
+            A border layer, setting the border vertices of a mesh to high costs (dangerous).
+        </description>
+    </class>
     <class name="mesh_layers/RoughnessLayer"
             type="mesh_layers::RoughnessLayer"
             base_class_type="mesh_map::AbstractLayer">

--- a/mesh_layers/mesh_layers.xml
+++ b/mesh_layers/mesh_layers.xml
@@ -3,7 +3,7 @@
             type="mesh_layers::BorderLayer"
             base_class_type="mesh_map::AbstractLayer">
         <description>
-            A border layer, setting the border vertices of a mesh to high costs (dangerous).
+            A border layer, setting the border vertices of a mesh to high costs. Use this layer to prohibit the robot to navigate to the border of the mesh.
         </description>
     </class>
     <class name="mesh_layers/RoughnessLayer"

--- a/mesh_layers/src/border_layer.cpp
+++ b/mesh_layers/src/border_layer.cpp
@@ -1,0 +1,172 @@
+/*
+ *  Copyright 2020, Sebastian Pütz
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *  2. Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *
+ *  3. Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ *  authors:
+ *    Sebastian Pütz <spuetz@uni-osnabrueck.de>
+ *
+ */
+
+#include "mesh_layers/border_layer.h"
+
+#include <lvr2/algorithm/GeometryAlgorithms.hpp>
+#include <lvr2/algorithm/NormalAlgorithms.hpp>
+#include <pluginlib/class_list_macros.hpp>
+
+PLUGINLIB_EXPORT_CLASS(mesh_layers::BorderLayer, mesh_map::AbstractLayer)
+
+namespace mesh_layers
+{
+bool BorderLayer::readLayer()
+{
+  RCLCPP_INFO_STREAM(node_->get_logger(), "Try to read border costs from map file...");
+  auto border_costs_opt = mesh_io_ptr_->getDenseAttributeMap<lvr2::DenseVertexMap<float>>("border");
+
+  if (border_costs_opt)
+  {
+    RCLCPP_INFO_STREAM(node_->get_logger(), "Border costs have been read successfully.");
+    border_costs_ = border_costs_opt.get();
+
+    return computeLethals();
+  }
+
+  return false;
+}
+
+bool BorderLayer::computeLethals()
+{
+  RCLCPP_INFO_STREAM(node_->get_logger(), "Compute lethals for \"" << layer_name_ << "\" (Border Layer) with threshold "
+                                           << config_.threshold);
+  lethal_vertices_.clear();
+  for (auto vH : border_costs_)
+  {
+    if (border_costs_[vH] > config_.threshold)
+    {
+      lethal_vertices_.insert(vH);
+    }
+  }
+  RCLCPP_INFO_STREAM(node_->get_logger(), "Found " << lethal_vertices_.size() << " lethal vertices.");
+  return true;
+}
+
+bool BorderLayer::writeLayer()
+{
+  RCLCPP_INFO_STREAM(node_->get_logger(), "Saving border costs to map file...");
+  if (mesh_io_ptr_->addDenseAttributeMap(border_costs_, "border"))
+  {
+    RCLCPP_INFO_STREAM(node_->get_logger(), "Saved border costs to map file.");
+    return true;
+  }
+  else
+  {
+    RCLCPP_ERROR_STREAM(node_->get_logger(), "Could not save height differences to map file!");
+    return false;
+  }
+}
+
+float BorderLayer::threshold()
+{
+  return config_.threshold;
+}
+
+bool BorderLayer::computeLayer()
+{
+  border_costs_ = lvr2::calcBorderCosts(*mesh_ptr_, config_.border_cost);
+  return computeLethals();
+}
+
+lvr2::VertexMap<float>& BorderLayer::costs()
+{
+  return border_costs_;
+}
+
+rcl_interfaces::msg::SetParametersResult BorderLayer::reconfigureCallback(std::vector<rclcpp::Parameter> parameters)
+{
+  rcl_interfaces::msg::SetParametersResult result;
+  result.successful = true;
+
+  bool has_threshold_changed = false;
+  for (auto parameter : parameters) {
+    if (parameter.get_name() == mesh_map::MeshMap::MESH_MAP_NAMESPACE + "." + layer_name_ + ".threshold") {
+      config_.threshold = parameter.as_double();
+      has_threshold_changed = true;
+    } else if (parameter.get_name() == mesh_map::MeshMap::MESH_MAP_NAMESPACE + "." + layer_name_ + ".border_cost") {
+      config_.border_cost = parameter.as_double();
+    } else if (parameter.get_name() == mesh_map::MeshMap::MESH_MAP_NAMESPACE + "." + layer_name_ + ".factor") {
+      config_.factor = parameter.as_double();
+    }
+  }
+
+  if (has_threshold_changed) {
+    RCLCPP_INFO_STREAM(node_->get_logger(), "Recompute lethals and notify change from " << layer_name_ << " due to cfg change.");
+    computeLethals();
+    notifyChange();
+  }
+
+  return result;
+}
+
+
+bool BorderLayer::initialize()
+{
+  { // threshold
+    rcl_interfaces::msg::ParameterDescriptor descriptor;
+    descriptor.description = "Threshold for the local border costs to be counted as lethal.";
+    rcl_interfaces::msg::FloatingPointRange range;
+    range.from_value = 0.05;
+    range.to_value = 1.0;
+    descriptor.floating_point_range.push_back(range);
+    config_.threshold = node_->declare_parameter(mesh_map::MeshMap::MESH_MAP_NAMESPACE + "." + layer_name_ + ".threshold", config_.threshold);
+  }
+  { // border cost
+    rcl_interfaces::msg::ParameterDescriptor descriptor;
+    descriptor.description = "The cost value used for the border vertices.";
+    rcl_interfaces::msg::FloatingPointRange range;
+    range.from_value = 0.02;
+    range.to_value = 10.0;
+    descriptor.floating_point_range.push_back(range);
+    config_.border_cost = node_->declare_parameter(mesh_map::MeshMap::MESH_MAP_NAMESPACE + "." + layer_name_ + ".border_cost", config_.border_cost);
+  }
+  { // factor
+    rcl_interfaces::msg::ParameterDescriptor descriptor;
+    descriptor.description = "Using this factor to weight this layer.";
+    rcl_interfaces::msg::FloatingPointRange range;
+    range.from_value = 0.0;
+    range.to_value = 1.0;
+    descriptor.floating_point_range.push_back(range);
+    config_.factor = node_->declare_parameter(mesh_map::MeshMap::MESH_MAP_NAMESPACE + "." + layer_name_ + ".factor", config_.factor);
+  }
+  dyn_params_handler_ = node_->add_on_set_parameters_callback(std::bind(
+      &BorderLayer::reconfigureCallback, this, std::placeholders::_1));
+  return true;
+}
+
+} /* namespace mesh_layers */

--- a/mesh_layers/src/border_layer.cpp
+++ b/mesh_layers/src/border_layer.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2020, Sebastian Pütz
+ *  Copyright 2020, Alexander Mock
  *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions
@@ -31,7 +31,7 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *
  *  authors:
- *    Sebastian Pütz <spuetz@uni-osnabrueck.de>
+ *    Alexander Mock <amock@uos.de>
  *
  */
 


### PR DESCRIPTION
I am introducing a new layer to mesh navigation: “border layer”. It's a simple layer that sets all vertices at the border of the mesh to lethal costs. You can use it if you don't want your robot to fall off a cliff. The downside of this layer, however, is that if you want to continue mapping, you usually have to travel to these border regions to explore the surrounding area and thus expand the map. Driving directly to the border would not be possible anymore if you use the border layer. However, I think that in most cases driving close to the border is enough to see enough to expand the map. The resulting costs look like this:

![image](https://github.com/user-attachments/assets/a8dfe2fe-1f91-4379-96a4-30b17152474d)

green: zero cost (safe to traverse according to the “border” layer)
red: lethal costs (do not go here)