### PR TITLE
Fix: the CVP Mesh Planner did not use the goal orientation set by the user and it included vertices above the cost limit in the path planning

### DIFF
--- a/cvp_mesh_planner/src/cvp_mesh_planner.cpp
+++ b/cvp_mesh_planner/src/cvp_mesh_planner.cpp
@@ -105,8 +105,7 @@ uint32_t CVPMeshPlanner::makePlan(const geometry_msgs::msg::PoseStamped& start,
 
     geometry_msgs::msg::PoseStamped pose;
     pose.header = header;
-    pose.pose = mesh_map::calculatePoseFromPosition(vec, goal_vec, face_normals[fH], dir_length);
-    cost += dir_length;
+    pose.pose = goal.pose;
     plan.push_back(pose);
   }
 

--- a/cvp_mesh_planner/src/cvp_mesh_planner.cpp
+++ b/cvp_mesh_planner/src/cvp_mesh_planner.cpp
@@ -781,6 +781,11 @@ uint32_t CVPMeshPlanner::waveFrontPropagation(const mesh_map::Vector& original_s
         else if (fixed[a] && fixed[b] && !fixed[c])
         {
           // c is free
+          // Skip vertices above the cost limit
+          if (costs[c] > config_.cost_limit)
+          {
+            continue;
+          }
 #ifdef USE_UPDATE_WITH_S
           if (waveFrontUpdateWithS(distances, edge_weights, a, b, c))
 #elif defined USE_UPDATE_FMM
@@ -799,6 +804,11 @@ uint32_t CVPMeshPlanner::waveFrontPropagation(const mesh_map::Vector& original_s
         else if (fixed[a] && !fixed[b] && fixed[c])
         {
           // b is free
+          // Skip vertices above the cost limit
+          if (costs[b] > config_.cost_limit)
+          {
+            continue;
+          }
 #ifdef USE_UPDATE_WITH_S
           if (waveFrontUpdateWithS(distances, edge_weights, c, a, b))
 #elif defined USE_UPDATE_FMM
@@ -817,6 +827,11 @@ uint32_t CVPMeshPlanner::waveFrontPropagation(const mesh_map::Vector& original_s
         else if (!fixed[a] && fixed[b] && fixed[c])
         {
           // a if free
+          // Skip vertices above the cost limit
+          if (costs[a] > config_.cost_limit)
+          {
+            continue;
+          }
 #ifdef USE_UPDATE_WITH_S
           if (waveFrontUpdateWithS(distances, edge_weights, b, c, a))
 #elif defined USE_UPDATE_FMM


### PR DESCRIPTION
The CVP Mesh Planner did overwrite the goal pose orientation with a unit quaternion.

Also the CVP Mesh Planner did expand/update vertices with lethal cost if these vertices were part of a triangle with two other non lethal vertices. This could lead the robot to plan a path/drive through vertices with lethal costs.