### PR TITLE
Fix: inflation layer cost did not monotonically decrease with small inflation radii

### DIFF
--- a/mesh_layers/src/inflation_layer.cpp
+++ b/mesh_layers/src/inflation_layer.cpp
@@ -240,7 +240,8 @@ float InflationLayer::fading(const float val)
   // Inflation radius
   if (val > config_.inscribed_radius)
   {
-    float alpha = (sqrt(val) - config_.inscribed_radius) / (config_.inflation_radius - config_.inscribed_radius) * M_PI;
+    // Map values from [config_.inscribed_radius, config_.inflation_radius] to [0, pi]
+    float alpha = ((val - config_.inscribed_radius) / (config_.inflation_radius - config_.inscribed_radius)) * M_PI;
     return config_.inscribed_value * (cos(alpha) + 1) / 2.0;
   }
 


### PR DESCRIPTION
The InflationLayers cost function did exhibit some strange behavior with smaller `inflation` and `inscribed` radii.

This is the original cost layer:
![layer](https://github.com/user-attachments/assets/7becfdac-d149-4bec-9b55-2b720bba4888)

This is the `inflation` layer with the original cost fading function:
![old_fading](https://github.com/user-attachments/assets/4184a824-2fe1-46e9-b667-d553d7738396)
As we can see the cost decreases first and then increases again at the end of the inflation radius.

I have plotted the original cost function with `inscribed` radius at 0.3m and `inflation` radius at 0.5m, the X-Axis is the distance from the Vertex being inflated. The plot assumes that the `inscribed_value` parameter is 1.0.
![old_function](https://github.com/user-attachments/assets/33b292d4-a67e-4979-bdd2-7c2443daa51a)
We can see that at the 0.3m the cost is about 0.1 and then increases to 1.0 at 0.5m.

I have changed the calculation of the `alpha` value to be linearly decreasing between the `inscribed` and the `inflation` radius. This then leads to the following cost function, again the `inscribed` radius is 0.3m, the `inflation` radius is 0.5m and the `inscribed_value` parameter is 1.0:
![new_function](https://github.com/user-attachments/assets/f388eef6-90bf-4067-9fd5-9756390b257c)
Here the cost starts with 1.0 at the `inscribed` radius (0.3m) and then decreases until it reaches 0 at the end of the `inflation` radius (0.5m).

The cost layer with the new function looks like this:
![new_fading](https://github.com/user-attachments/assets/0ea96631-adf5-4033-82af-00024438679b)

