### PR TITLE
Dynamic loading of different mesh formats

### DIFF
--- a/mesh_layers/CMakeLists.txt
+++ b/mesh_layers/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.8)
 project(mesh_layers)
 
-find_package(ament_cmake_ros COMPONENTS)
+find_package(ament_cmake_ros REQUIRED)
 find_package(mesh_map)
 find_package(LVR2)
 

--- a/mesh_layers/include/mesh_layers/border_layer.h
+++ b/mesh_layers/include/mesh_layers/border_layer.h
@@ -141,9 +141,6 @@ class BorderLayer : public mesh_map::AbstractLayer
     double border_cost = 1.0;
     double factor = 1.0;
   } config_;
-
-  // put this to base class?
-  std::string name;
 };
 
 } /* namespace mesh_layers */

--- a/mesh_layers/include/mesh_layers/border_layer.h
+++ b/mesh_layers/include/mesh_layers/border_layer.h
@@ -141,6 +141,9 @@ class BorderLayer : public mesh_map::AbstractLayer
     double border_cost = 1.0;
     double factor = 1.0;
   } config_;
+
+  // put this to base class?
+  std::string name;
 };
 
 } /* namespace mesh_layers */

--- a/mesh_layers/src/border_layer.cpp
+++ b/mesh_layers/src/border_layer.cpp
@@ -48,7 +48,7 @@ namespace mesh_layers
 bool BorderLayer::readLayer()
 {
   RCLCPP_INFO_STREAM(node_->get_logger(), "Try to read border costs from map file...");
-  auto border_costs_opt = mesh_io_ptr_->getDenseAttributeMap<lvr2::DenseVertexMap<float> >("border");
+  auto border_costs_opt = mesh_io_ptr_->getDenseAttributeMap<lvr2::DenseVertexMap<float> >(layer_name_);
 
   if (border_costs_opt)
   {
@@ -79,7 +79,7 @@ bool BorderLayer::computeLethals()
 bool BorderLayer::writeLayer()
 {
   RCLCPP_INFO_STREAM(node_->get_logger(), "Saving border costs to map file...");
-  if (mesh_io_ptr_->addDenseAttributeMap(border_costs_, "border"))
+  if (mesh_io_ptr_->addDenseAttributeMap(border_costs_, layer_name_))
   {
     RCLCPP_INFO_STREAM(node_->get_logger(), "Saved border costs to map file.");
     return true;
@@ -150,7 +150,6 @@ rcl_interfaces::msg::SetParametersResult BorderLayer::reconfigureCallback(std::v
 
   return result;
 }
-
 
 bool BorderLayer::initialize()
 {

--- a/mesh_layers/src/height_diff_layer.cpp
+++ b/mesh_layers/src/height_diff_layer.cpp
@@ -48,7 +48,7 @@ namespace mesh_layers
 bool HeightDiffLayer::readLayer()
 {
   RCLCPP_INFO_STREAM(node_->get_logger(), "Try to read height differences from map file...");
-  auto height_diff_opt = mesh_io_ptr_->getDenseAttributeMap<lvr2::DenseVertexMap<float>>("height_diff");
+  auto height_diff_opt = mesh_io_ptr_->getDenseAttributeMap<lvr2::DenseVertexMap<float>>(layer_name_);
 
   if (height_diff_opt)
   {
@@ -78,7 +78,7 @@ bool HeightDiffLayer::computeLethals()
 bool HeightDiffLayer::writeLayer()
 {
   RCLCPP_INFO_STREAM(node_->get_logger(), "Saving height_differences to map file...");
-  if (mesh_io_ptr_->addDenseAttributeMap(height_diff_, "height_diff"))
+  if (mesh_io_ptr_->addDenseAttributeMap(height_diff_, layer_name_))
   {
     RCLCPP_INFO_STREAM(node_->get_logger(), "Saved height differences to map file.");
     return true;

--- a/mesh_layers/src/inflation_layer.cpp
+++ b/mesh_layers/src/inflation_layer.cpp
@@ -50,7 +50,7 @@ bool InflationLayer::readLayer()
 {
   // riskiness
   RCLCPP_INFO_STREAM(node_->get_logger(), "Try to read riskiness from map file...");
-  auto riskiness_opt = mesh_io_ptr_->getDenseAttributeMap<lvr2::DenseVertexMap<float>>("riskiness");
+  auto riskiness_opt = mesh_io_ptr_->getDenseAttributeMap<lvr2::DenseVertexMap<float>>(layer_name_);
 
   if (riskiness_opt)
   {
@@ -68,7 +68,7 @@ bool InflationLayer::writeLayer()
 {
   RCLCPP_INFO_STREAM(node_->get_logger(), "Saving " << riskiness_.numValues() << " riskiness values to map file...");
 
-  if (mesh_io_ptr_->addDenseAttributeMap(riskiness_, "riskiness"))
+  if (mesh_io_ptr_->addDenseAttributeMap(riskiness_, layer_name_))
   {
     RCLCPP_INFO_STREAM(node_->get_logger(), "Saved riskiness to map file.");
     return true;

--- a/mesh_layers/src/inflation_layer.cpp
+++ b/mesh_layers/src/inflation_layer.cpp
@@ -678,61 +678,68 @@ bool InflationLayer::initialize()
   { // inscribed_radius
     rcl_interfaces::msg::ParameterDescriptor descriptor;
     descriptor.description = "Defines the inscribed radius.";
+    descriptor.type = rcl_interfaces::msg::ParameterType::PARAMETER_DOUBLE;
     rcl_interfaces::msg::FloatingPointRange range;
     range.from_value = 0.01;
     range.to_value = 1.0;
     descriptor.floating_point_range.push_back(range);
-    config_.inscribed_radius = node_->declare_parameter(mesh_map::MeshMap::MESH_MAP_NAMESPACE + "." + layer_name_ + ".inscribed_radius", config_.inscribed_radius);
+    config_.inscribed_radius = node_->declare_parameter(mesh_map::MeshMap::MESH_MAP_NAMESPACE + "." + layer_name_ + ".inscribed_radius", config_.inscribed_radius, descriptor);
   }
   { // inflation_radius
     rcl_interfaces::msg::ParameterDescriptor descriptor;
     descriptor.description = "Defines the maximum inflation radius.";
+    descriptor.type = rcl_interfaces::msg::ParameterType::PARAMETER_DOUBLE;
     rcl_interfaces::msg::FloatingPointRange range;
     range.from_value = 0.01;
     range.to_value = 3.0;
     descriptor.floating_point_range.push_back(range);
-    config_.inflation_radius = node_->declare_parameter(mesh_map::MeshMap::MESH_MAP_NAMESPACE + "." + layer_name_ + ".inflation_radius", config_.inflation_radius);
+    config_.inflation_radius = node_->declare_parameter(mesh_map::MeshMap::MESH_MAP_NAMESPACE + "." + layer_name_ + ".inflation_radius", config_.inflation_radius, descriptor);
   }
   { // factor
     rcl_interfaces::msg::ParameterDescriptor descriptor;
     descriptor.description = "The factor to weight this layer";
+    descriptor.type = rcl_interfaces::msg::ParameterType::PARAMETER_DOUBLE;
     rcl_interfaces::msg::FloatingPointRange range;
     range.from_value = 0.0;
     range.to_value = 1.-0;
     descriptor.floating_point_range.push_back(range);
-    config_.factor = node_->declare_parameter(mesh_map::MeshMap::MESH_MAP_NAMESPACE + "." + layer_name_ + ".factor", config_.factor);
+    config_.factor = node_->declare_parameter(mesh_map::MeshMap::MESH_MAP_NAMESPACE + "." + layer_name_ + ".factor", config_.factor, descriptor);
   }
   { // lethal_value
     rcl_interfaces::msg::ParameterDescriptor descriptor;
     descriptor.description = "Defines the 'lethal' value for obstacles. -1 results in infinity";
+    descriptor.type = rcl_interfaces::msg::ParameterType::PARAMETER_DOUBLE;
     rcl_interfaces::msg::FloatingPointRange range;
     range.from_value = -1.0;
     range.to_value = 100000.0;
     descriptor.floating_point_range.push_back(range);
-    config_.lethal_value = node_->declare_parameter(mesh_map::MeshMap::MESH_MAP_NAMESPACE + "." + layer_name_ + ".lethal_value", config_.lethal_value);
+    config_.lethal_value = node_->declare_parameter(mesh_map::MeshMap::MESH_MAP_NAMESPACE + "." + layer_name_ + ".lethal_value", config_.lethal_value, descriptor);
   }
   { // inscribed_value
     rcl_interfaces::msg::ParameterDescriptor descriptor;
     descriptor.description = "Defines the 'inscribed' value for obstacles.";
+    descriptor.type = rcl_interfaces::msg::ParameterType::PARAMETER_DOUBLE;
     rcl_interfaces::msg::FloatingPointRange range;
     range.from_value = 0.0;
     range.to_value = 100000.0;
     descriptor.floating_point_range.push_back(range);
-    config_.inscribed_value = node_->declare_parameter(mesh_map::MeshMap::MESH_MAP_NAMESPACE + "." + layer_name_ + ".inscribed_value", config_.inscribed_value);
+    config_.inscribed_value = node_->declare_parameter(mesh_map::MeshMap::MESH_MAP_NAMESPACE + "." + layer_name_ + ".inscribed_value", config_.inscribed_value, descriptor);
   }
   { // min_contour_size
     rcl_interfaces::msg::ParameterDescriptor descriptor;
     descriptor.description = "Defines the minimum size for a contour to be classified as 'lethal'.";
+    descriptor.type = rcl_interfaces::msg::ParameterType::PARAMETER_INTEGER;
     rcl_interfaces::msg::IntegerRange range;
     range.from_value = 0;
     range.to_value = 100000;
     descriptor.integer_range.push_back(range);
-    config_.min_contour_size = node_->declare_parameter(mesh_map::MeshMap::MESH_MAP_NAMESPACE + "." + layer_name_ + ".min_contour_size", config_.min_contour_size);
+    config_.min_contour_size = node_->declare_parameter(mesh_map::MeshMap::MESH_MAP_NAMESPACE + "." + layer_name_ + ".min_contour_size", config_.min_contour_size, descriptor);
   }
   { // repulsive_field
     rcl_interfaces::msg::ParameterDescriptor descriptor;
     descriptor.description = "Enable the repulsive vector field.";
-    config_.repulsive_field = node_->declare_parameter(mesh_map::MeshMap::MESH_MAP_NAMESPACE + "." + layer_name_ + ".repulsive_field", config_.repulsive_field);
+    descriptor.type = rcl_interfaces::msg::ParameterType::PARAMETER_BOOL;
+    config_.repulsive_field = node_->declare_parameter(mesh_map::MeshMap::MESH_MAP_NAMESPACE + "." + layer_name_ + ".repulsive_field", config_.repulsive_field, descriptor);
   }
   dyn_params_handler_ = node_->add_on_set_parameters_callback(std::bind(&InflationLayer::reconfigureCallback, this, std::placeholders::_1));
   return true;

--- a/mesh_layers/src/ridge_layer.cpp
+++ b/mesh_layers/src/ridge_layer.cpp
@@ -50,7 +50,7 @@ namespace mesh_layers
 bool RidgeLayer::readLayer()
 {
   RCLCPP_INFO_STREAM(node_->get_logger(), "Try to read ridge from map file...");
-  auto ridge_opt = mesh_io_ptr_->getDenseAttributeMap<lvr2::DenseVertexMap<float>>("ridge");
+  auto ridge_opt = mesh_io_ptr_->getDenseAttributeMap<lvr2::DenseVertexMap<float>>(layer_name_);
   if (ridge_opt)
   {
     RCLCPP_INFO_STREAM(node_->get_logger(), "Successfully read ridge from map file.");
@@ -63,7 +63,7 @@ bool RidgeLayer::readLayer()
 
 bool RidgeLayer::writeLayer()
 {
-  if (mesh_io_ptr_->addDenseAttributeMap(ridge_, "ridge"))
+  if (mesh_io_ptr_->addDenseAttributeMap(ridge_, layer_name_))
   {
     RCLCPP_INFO_STREAM(node_->get_logger(), "Saved ridge to map file.");
     return true;

--- a/mesh_layers/src/ridge_layer.cpp
+++ b/mesh_layers/src/ridge_layer.cpp
@@ -219,29 +219,32 @@ bool RidgeLayer::initialize()
   { // threshold
     rcl_interfaces::msg::ParameterDescriptor descriptor;
     descriptor.description = "Threshold for the local ridge to be counted as lethal.";
+    descriptor.type = rcl_interfaces::msg::ParameterType::PARAMETER_DOUBLE;
     rcl_interfaces::msg::FloatingPointRange range;
     range.from_value = 0.01;
     range.to_value = 3.1415;
     descriptor.floating_point_range.push_back(range);
-    config_.threshold = node_->declare_parameter(mesh_map::MeshMap::MESH_MAP_NAMESPACE + "." + layer_name_ + ".threshold", config_.threshold);
+    config_.threshold = node_->declare_parameter(mesh_map::MeshMap::MESH_MAP_NAMESPACE + "." + layer_name_ + ".threshold", config_.threshold, descriptor);
   }
   { // radius
     rcl_interfaces::msg::ParameterDescriptor descriptor;
     descriptor.description = "Radius of the inscribed area.";
+    descriptor.type = rcl_interfaces::msg::ParameterType::PARAMETER_DOUBLE;
     rcl_interfaces::msg::FloatingPointRange range;
     range.from_value = 0.01;
     range.to_value = 1.0;
     descriptor.floating_point_range.push_back(range);
-    config_.radius = node_->declare_parameter(mesh_map::MeshMap::MESH_MAP_NAMESPACE + "." + layer_name_ + ".radius", config_.radius);
+    config_.radius = node_->declare_parameter(mesh_map::MeshMap::MESH_MAP_NAMESPACE + "." + layer_name_ + ".radius", config_.radius, descriptor);
   }
   { // factor
     rcl_interfaces::msg::ParameterDescriptor descriptor;
     descriptor.description = "The local ridge factor to weight this layer.";
+    descriptor.type = rcl_interfaces::msg::ParameterType::PARAMETER_DOUBLE;
     rcl_interfaces::msg::FloatingPointRange range;
     range.from_value = 0.0;
     range.to_value = 1.0;
     descriptor.floating_point_range.push_back(range);
-    config_.factor = node_->declare_parameter(mesh_map::MeshMap::MESH_MAP_NAMESPACE + "." + layer_name_ + ".factor", config_.factor);
+    config_.factor = node_->declare_parameter(mesh_map::MeshMap::MESH_MAP_NAMESPACE + "." + layer_name_ + ".factor", config_.factor, descriptor);
   }
   dyn_params_handler_ = node_->add_on_set_parameters_callback(std::bind(
       &RidgeLayer::reconfigureCallback, this, std::placeholders::_1));

--- a/mesh_layers/src/roughness_layer.cpp
+++ b/mesh_layers/src/roughness_layer.cpp
@@ -169,29 +169,32 @@ bool RoughnessLayer::initialize() {
   { // threshold
     rcl_interfaces::msg::ParameterDescriptor descriptor;
     descriptor.description = "Threshold for the local roughness to be counted as lethal.";
+    descriptor.type = rcl_interfaces::msg::ParameterType::PARAMETER_DOUBLE;
     rcl_interfaces::msg::FloatingPointRange range;
     range.from_value = 0.01;
     range.to_value = 3.1415;
     descriptor.floating_point_range.push_back(range);
-    config_.threshold = node_->declare_parameter(mesh_map::MeshMap::MESH_MAP_NAMESPACE + "." + layer_name_ + ".threshold", config_.threshold);
+    config_.threshold = node_->declare_parameter(mesh_map::MeshMap::MESH_MAP_NAMESPACE + "." + layer_name_ + ".threshold", config_.threshold, descriptor);
   }
   { // radius
     rcl_interfaces::msg::ParameterDescriptor descriptor;
     descriptor.description = "The radius used for calculating the local roughness.";
+    descriptor.type = rcl_interfaces::msg::ParameterType::PARAMETER_DOUBLE;
     rcl_interfaces::msg::FloatingPointRange range;
     range.from_value = 0.02;
     range.to_value = 1.0;
     descriptor.floating_point_range.push_back(range);
-    config_.radius = node_->declare_parameter(mesh_map::MeshMap::MESH_MAP_NAMESPACE + "." + layer_name_ + ".radius", config_.radius);
+    config_.radius = node_->declare_parameter(mesh_map::MeshMap::MESH_MAP_NAMESPACE + "." + layer_name_ + ".radius", config_.radius, descriptor);
   }
   { // factor
     rcl_interfaces::msg::ParameterDescriptor descriptor;
     descriptor.description = "The local roughness factor to weight this layer.";
+    descriptor.type = rcl_interfaces::msg::ParameterType::PARAMETER_DOUBLE;
     rcl_interfaces::msg::FloatingPointRange range;
     range.from_value = 0.0;
     range.to_value = 1.0;
     descriptor.floating_point_range.push_back(range);
-    config_.factor = node_->declare_parameter(mesh_map::MeshMap::MESH_MAP_NAMESPACE + "." + layer_name_ + ".factor", config_.factor);
+    config_.factor = node_->declare_parameter(mesh_map::MeshMap::MESH_MAP_NAMESPACE + "." + layer_name_ + ".factor", config_.factor, descriptor);
   }
   dyn_params_handler_ = node_->add_on_set_parameters_callback(std::bind(
       &RoughnessLayer::reconfigureCallback, this, std::placeholders::_1));

--- a/mesh_layers/src/roughness_layer.cpp
+++ b/mesh_layers/src/roughness_layer.cpp
@@ -49,7 +49,7 @@ bool RoughnessLayer::readLayer() {
   RCLCPP_INFO_STREAM(node_->get_logger(), "Try to read roughness from map file...");
   auto roughness_opt =
       mesh_io_ptr_->getDenseAttributeMap<lvr2::DenseVertexMap<float>>(
-          "roughness");
+          layer_name_);
   if (roughness_opt) {
     RCLCPP_INFO_STREAM(node_->get_logger(), "Successfully read roughness from map file.");
     roughness_ = roughness_opt.get();
@@ -60,7 +60,7 @@ bool RoughnessLayer::readLayer() {
 }
 
 bool RoughnessLayer::writeLayer() {
-  if (mesh_io_ptr_->addDenseAttributeMap(roughness_, "roughness")) {
+  if (mesh_io_ptr_->addDenseAttributeMap(roughness_, layer_name_)) {
     RCLCPP_INFO_STREAM(node_->get_logger(), "Saved roughness to map file.");
     return true;
   } else {

--- a/mesh_layers/src/steepness_layer.cpp
+++ b/mesh_layers/src/steepness_layer.cpp
@@ -194,20 +194,22 @@ bool SteepnessLayer::initialize()
   { // threshold
     rcl_interfaces::msg::ParameterDescriptor descriptor;
     descriptor.description = "Threshold for the local steepness to be counted as lethal.";
+    descriptor.type = rcl_interfaces::msg::ParameterType::PARAMETER_DOUBLE;
     rcl_interfaces::msg::FloatingPointRange range;
     range.from_value = 0.01;
     range.to_value = 3.1415;
     descriptor.floating_point_range.push_back(range);
-    config_.threshold = node_->declare_parameter(mesh_map::MeshMap::MESH_MAP_NAMESPACE + "." + layer_name_ + ".threshold", config_.threshold);
+    config_.threshold = node_->declare_parameter(mesh_map::MeshMap::MESH_MAP_NAMESPACE + "." + layer_name_ + ".threshold", config_.threshold, descriptor);
   }
   { // factor
     rcl_interfaces::msg::ParameterDescriptor descriptor;
     descriptor.description = "The local steepness factor to weight this layer.";
+    descriptor.type = rcl_interfaces::msg::ParameterType::PARAMETER_DOUBLE;
     rcl_interfaces::msg::FloatingPointRange range;
     range.from_value = 0.0;
     range.to_value = 1.0;
     descriptor.floating_point_range.push_back(range);
-    config_.factor = node_->declare_parameter(mesh_map::MeshMap::MESH_MAP_NAMESPACE + "." + layer_name_ + ".factor", config_.factor);
+    config_.factor = node_->declare_parameter(mesh_map::MeshMap::MESH_MAP_NAMESPACE + "." + layer_name_ + ".factor", config_.factor, descriptor);
   }
   dyn_params_handler_ = node_->add_on_set_parameters_callback(std::bind(
       &SteepnessLayer::reconfigureCallback, this, std::placeholders::_1));

--- a/mesh_layers/src/steepness_layer.cpp
+++ b/mesh_layers/src/steepness_layer.cpp
@@ -49,7 +49,7 @@ namespace mesh_layers
 bool SteepnessLayer::readLayer()
 {
   RCLCPP_INFO_STREAM(node_->get_logger(), "Try to read steepness from map file...");
-  auto steepness_opt = mesh_io_ptr_->getDenseAttributeMap<lvr2::DenseVertexMap<float>>("steepness");
+  auto steepness_opt = mesh_io_ptr_->getDenseAttributeMap<lvr2::DenseVertexMap<float>>(layer_name_);
   if (steepness_opt)
   {
     RCLCPP_INFO_STREAM(node_->get_logger(), "Successfully read steepness from map file.");
@@ -62,7 +62,7 @@ bool SteepnessLayer::readLayer()
 
 bool SteepnessLayer::writeLayer()
 {
-  if (mesh_io_ptr_->addDenseAttributeMap(steepness_, "steepness"))
+  if (mesh_io_ptr_->addDenseAttributeMap(steepness_, layer_name_))
   {
     RCLCPP_INFO_STREAM(node_->get_logger(), "Saved steepness to map file.");
     return true;

--- a/mesh_map/CMakeLists.txt
+++ b/mesh_map/CMakeLists.txt
@@ -13,6 +13,7 @@ set(dependencies
   tf2_geometry_msgs
   tf2_ros
   visualization_msgs
+  std_srvs
 )
 foreach(dep IN LISTS dependencies)
   find_package(${dep} REQUIRED)

--- a/mesh_map/CMakeLists.txt
+++ b/mesh_map/CMakeLists.txt
@@ -19,9 +19,8 @@ foreach(dep IN LISTS dependencies)
 endforeach()
 
 find_package(LVR2 REQUIRED)
+find_package(assimp REQUIRED)
 find_package(MPI)
-# this is nowhere used
-# find_package(Boost REQUIRED COMPONENTS system) 
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(JSONCPP jsoncpp)
 
@@ -36,10 +35,12 @@ add_library(${PROJECT_NAME}
 target_include_directories(${PROJECT_NAME} PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>
-  ${LVR2_INCLUDE_DIRS})
+  ${LVR2_INCLUDE_DIRS}
+  ${ASSIMP_INCLUDE_DIRS})
 ament_target_dependencies(${PROJECT_NAME} ${dependencies})
 target_link_libraries(${PROJECT_NAME} 
     ${LVR2_LIBRARIES}
+    ${ASSIMP_LIBRARIES}
     ${MPI_CXX_LIBRARIES}
 )
 

--- a/mesh_map/include/mesh_map/abstract_layer.h
+++ b/mesh_map/include/mesh_map/abstract_layer.h
@@ -156,9 +156,13 @@ public:
   /**
    * @brief Initializes the layer plugin under the mesh_map namespace ans sets some basic attributes.
    */
-  virtual bool initialize(const std::string& name, const notify_func notify_update,
-                          std::shared_ptr<mesh_map::MeshMap>& map, std::shared_ptr<lvr2::HalfEdgeMesh<Vector>>& mesh,
-                          std::shared_ptr<lvr2::AttributeMeshIOBase>& io, const rclcpp::Node::SharedPtr& node)
+  virtual bool initialize(
+    const std::string& name,
+    const notify_func notify_update,
+    std::shared_ptr<mesh_map::MeshMap>& map,
+    std::shared_ptr<lvr2::HalfEdgeMesh<Vector>>& mesh,
+    std::shared_ptr<lvr2::AttributeMeshIOBase>& io,
+    const rclcpp::Node::SharedPtr& node)
   {
     layer_name_ = name;
     node_ = node;

--- a/mesh_map/include/mesh_map/mesh_map.h
+++ b/mesh_map/include/mesh_map/mesh_map.h
@@ -398,11 +398,14 @@ public:
    */
   mesh_map::AbstractLayer::Ptr layer(const std::string& layer_name);
 
+  //! This is an abstract interface to load mesh information from somewhere
+  //! The most default case is loading from a HDF5 file
+  //! However we could also implement a server connection here
+  //! We might use the pluginlib for that
   std::shared_ptr<lvr2::AttributeMeshIOBase> mesh_io_ptr;
   std::shared_ptr<lvr2::HalfEdgeMesh<Vector>> mesh_ptr;
 
   lvr2::DenseVertexMap<bool> invalid;
-
 private:
   //! plugin class loader for for the layer plugins
   pluginlib::ClassLoader<mesh_map::AbstractLayer> layer_loader;
@@ -424,31 +427,17 @@ private:
   //! global frame / coordinate system id
   std::string global_frame;
 
-  //! server url
-  std::string srv_url;
-
-  //! login username to connect to the server
-  std::string srv_username;
-
-  //! login password to connect to the server
-  std::string srv_password;
-
-  std::string mesh_layer;
-
-  double min_roughness;
-  double max_roughness;
-  double min_height_diff;
-  double max_height_diff;
-  double bb_min_x;
-  double bb_min_y;
-  double bb_min_z;
-  double bb_max_x;
-  double bb_max_y;
-  double bb_max_z;
-
-
+  //! mesh file 
   std::string mesh_file;
+
+  //! mesh part
   std::string mesh_part;
+  
+  //! mesh working file
+  std::string mesh_working_file;
+
+  //! mesh working part
+  std::string mesh_working_part;
 
   //! dynamic params callback handle
   rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr config_callback;

--- a/mesh_map/include/mesh_map/mesh_map.h
+++ b/mesh_map/include/mesh_map/mesh_map.h
@@ -401,7 +401,14 @@ public:
   mesh_map::AbstractLayer::Ptr layer(const std::string& layer_name);
 
   /**
-   * @brief calls 'saveLayer' on every active layer
+   * @brief calls 'saveLayer' on every active layer. Every layer itself writes its costs 
+   *        to the working file / part to a dataset named after the layer-name.
+   *  
+   * Example:
+   *  - Working file: "my_map.h5"
+   *  - Working mesh part: "my_mesh_part"
+   * 
+   * A BorderLayer of name 'border' would write the costs to "my_map.h5/my_mesh_part/channels/border"  
    */
   void saveLayers();
 

--- a/mesh_map/include/mesh_map/mesh_map.h
+++ b/mesh_map/include/mesh_map/mesh_map.h
@@ -53,7 +53,7 @@
 #include <std_msgs/msg/color_rgba.hpp>
 #include <tf2_ros/buffer.h>
 #include <visualization_msgs/msg/marker.hpp>
-#include <std_srvs/srv/empty.hpp>
+#include <std_srvs/srv/trigger.hpp>
 
 #include "nanoflann.hpp"
 #include "nanoflann_mesh_adaptor.h"
@@ -401,7 +401,7 @@ public:
   mesh_map::AbstractLayer::Ptr layer(const std::string& layer_name);
 
   /**
-   * @brief calls 'saveLayer' on every active layer. Every layer itself writes its costs 
+   * @brief calls 'writeLayer' on every active layer. Every layer itself writes its costs 
    *        to the working file / part to a dataset named after the layer-name.
    *  
    * Example:
@@ -409,8 +409,11 @@ public:
    *  - Working mesh part: "my_mesh_part"
    * 
    * A BorderLayer of name 'border' would write the costs to "my_map.h5/my_mesh_part/channels/border"  
+   * 
+   * @return Trigger response. If success is false, the message field is 
+   *      beeing filled with all the failed layer names seperated by comma 
    */
-  void saveLayers();
+  std_srvs::srv::Trigger::Response writeLayers();
 
   //! This is an abstract interface to load mesh information from somewhere
   //! The default case is loading from a HDF5 file
@@ -462,7 +465,7 @@ private:
   //! dynamic params callback handle
   rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr config_callback;
 
-  rclcpp::Service<std_srvs::srv::Empty>::SharedPtr save_service;
+  rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr save_service;
 
   // Reconfigurable parameters (see reconfigureCallback method)
   int min_contour_size;

--- a/mesh_map/include/mesh_map/mesh_map.h
+++ b/mesh_map/include/mesh_map/mesh_map.h
@@ -406,7 +406,7 @@ public:
   void saveLayers();
 
   //! This is an abstract interface to load mesh information from somewhere
-  //! The most default case is loading from a HDF5 file
+  //! The default case is loading from a HDF5 file
   //! However we could also implement a server connection here
   //! We might use the pluginlib for that
   std::shared_ptr<lvr2::AttributeMeshIOBase> mesh_io_ptr;

--- a/mesh_map/include/mesh_map/mesh_map.h
+++ b/mesh_map/include/mesh_map/mesh_map.h
@@ -53,6 +53,8 @@
 #include <std_msgs/msg/color_rgba.hpp>
 #include <tf2_ros/buffer.h>
 #include <visualization_msgs/msg/marker.hpp>
+#include <std_srvs/srv/empty.hpp>
+
 #include "nanoflann.hpp"
 #include "nanoflann_mesh_adaptor.h"
 
@@ -398,6 +400,11 @@ public:
    */
   mesh_map::AbstractLayer::Ptr layer(const std::string& layer_name);
 
+  /**
+   * @brief calls 'saveLayer' on every active layer
+   */
+  void saveLayers();
+
   //! This is an abstract interface to load mesh information from somewhere
   //! The most default case is loading from a HDF5 file
   //! However we could also implement a server connection here
@@ -441,6 +448,8 @@ private:
 
   //! dynamic params callback handle
   rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr config_callback;
+
+  rclcpp::Service<std_srvs::srv::Empty>::SharedPtr save_service;
 
   // Reconfigurable parameters (see reconfigureCallback method)
   int min_contour_size;

--- a/mesh_map/include/mesh_map/mesh_map.h
+++ b/mesh_map/include/mesh_map/mesh_map.h
@@ -434,16 +434,22 @@ private:
   //! global frame / coordinate system id
   std::string global_frame;
 
-  //! mesh file 
+  //! Filename of the input mesh. Can be any format the assimp library supports to load. 
+  //! https://github.com/assimp/assimp/blob/master/doc/Fileformats.md
   std::string mesh_file;
 
-  //! mesh part
+  //! Part of the mesh that is loaded for navigation
+  //! For HDF5 meshes this is the H5 group name of the desired mesh part
+  //! For standard formats this would be the internal path thorugh the scene graph to the mesh
   std::string mesh_part;
   
-  //! mesh working file
+  //! This is the filename of the file where the work is done. Choosing it differently from the 
+  //! input mesh prevents from accidentially overwrite your input data.
+  //! By default it will be set to the input mesh filename.
+  //! The working file must be of format HDF5
   std::string mesh_working_file;
 
-  //! mesh working part
+  //! The name of the mesh part that is used for navigation stored to the working file
   std::string mesh_working_part;
 
   //! dynamic params callback handle

--- a/mesh_map/include/mesh_map/util.h
+++ b/mesh_map/include/mesh_map/util.h
@@ -48,6 +48,9 @@
 #include <std_msgs/msg/color_rgba.hpp>
 #include <tf2/LinearMath/Vector3.h>
 
+#include <lvr2/io/MeshBuffer.hpp>
+#include <assimp/scene.h>
+
 namespace mesh_map
 {
 
@@ -57,6 +60,8 @@ typedef lvr2::Normal<float> Normal;
 //! use vectors with datatype folat
 typedef lvr2::BaseVector<float> Vector;
 
+
+lvr2::MeshBufferPtr extractMeshByName(const aiScene* ascene, std::string name);
 
 /**
  * @brief Function to build std_msgs color instances

--- a/mesh_map/package.xml
+++ b/mesh_map/package.xml
@@ -17,6 +17,7 @@
     <depend>tf2_ros</depend>
     <depend>tf2</depend>
     <depend>visualization_msgs</depend>
+    <depend>assimp</depend>
 
     <test_depend>ament_cmake_gmock</test_depend>
 

--- a/mesh_map/package.xml
+++ b/mesh_map/package.xml
@@ -17,6 +17,7 @@
     <depend>tf2_ros</depend>
     <depend>tf2</depend>
     <depend>visualization_msgs</depend>
+    <depend>std_srvs</depend>
     <depend>assimp</depend>
 
     <test_depend>ament_cmake_gmock</test_depend>

--- a/mesh_map/src/mesh_map.cpp
+++ b/mesh_map/src/mesh_map.cpp
@@ -109,9 +109,9 @@ MeshMap::MeshMap(tf2_ros::Buffer& tf, const rclcpp::Node::SharedPtr& node)
   cost_limit = node->declare_parameter(MESH_MAP_NAMESPACE + ".cost_limit", 1.0);
 
   mesh_file = node->declare_parameter(MESH_MAP_NAMESPACE + ".mesh_file", "");
-  
   mesh_part = node->declare_parameter(MESH_MAP_NAMESPACE + ".mesh_part", "");
   global_frame = node->declare_parameter(MESH_MAP_NAMESPACE + ".global_frame", "map");
+
   RCLCPP_INFO_STREAM(node->get_logger(), "mesh file is set to: " << mesh_file);
 
   // params for map layer names to types:
@@ -171,7 +171,8 @@ bool MeshMap::readMap()
       }
       
       // directly work on the input file
-      RCLCPP_INFO_STREAM(node->get_logger(), "Load \"" << mesh_part << "\" from file \"" << mesh_file << "\"...");
+      RCLCPP_INFO_STREAM(node->get_logger(), "Connect to \"" << mesh_working_part << "\" from file \"" << mesh_working_file << "\"...");
+
       auto hdf5_mesh_io = std::make_shared<HDF5MeshIO>();
       hdf5_mesh_io->open(mesh_working_file);
       hdf5_mesh_io->setMeshName(mesh_working_part);
@@ -179,6 +180,9 @@ bool MeshMap::readMap()
 
       if(mesh_file != mesh_working_file)
       {
+        RCLCPP_INFO_STREAM(node->get_logger(), "Initially loading \"" << mesh_part << "\" from file \"" << mesh_file << "\"...");
+      
+        std::cout << "Generate seperate working file..." << std::endl;
         lvr2::MeshBufferPtr mesh_buffer;
 
         // we have to create the working h5 first
@@ -188,6 +192,7 @@ bool MeshMap::readMap()
           hdf5_mesh_input->open(mesh_file);
           hdf5_mesh_input->setMeshName(mesh_part);
           mesh_buffer = hdf5_mesh_input->MeshIO::load(mesh_part);
+          // TODO: load all attributes?
         } else {
           // use another loader
           Assimp::Importer io;
@@ -209,7 +214,6 @@ bool MeshMap::readMap()
         // write
         hdf5_mesh_io->save(mesh_working_part, mesh_buffer);
       }
-
     }
     else
     {

--- a/mesh_map/src/mesh_map.cpp
+++ b/mesh_map/src/mesh_map.cpp
@@ -174,7 +174,7 @@ bool MeshMap::readMap()
         mesh_working_part = mesh_part;
         RCLCPP_INFO_STREAM(node->get_logger(), "Mesh Working Part is empty. Using mesh part as default: '" << mesh_working_part << "'");
       } else {
-        RCLCPP_INFO_STREAM(node->get_logger(), "Mesh Working Part is *not* empty: '" << mesh_working_part << "'");
+        RCLCPP_INFO_STREAM(node->get_logger(), "Using mesh working part from parameter: '" << mesh_working_part << "'");
       }
       
       if(fs::path(mesh_working_file).extension() != ".h5")

--- a/mesh_map/src/mesh_map.cpp
+++ b/mesh_map/src/mesh_map.cpp
@@ -172,7 +172,7 @@ bool MeshMap::readMap()
       if(mesh_working_part == "")
       {
         mesh_working_part = mesh_part;
-        RCLCPP_INFO_STREAM(node->get_logger(), "Mesh Working Part is empty. Using mesh part es default: '" << mesh_working_part << "'");
+        RCLCPP_INFO_STREAM(node->get_logger(), "Mesh Working Part is empty. Using mesh part as default: '" << mesh_working_part << "'");
       } else {
         RCLCPP_INFO_STREAM(node->get_logger(), "Mesh Working Part is *not* empty: '" << mesh_working_part << "'");
       }

--- a/mesh_map/src/mesh_map.cpp
+++ b/mesh_map/src/mesh_map.cpp
@@ -162,15 +162,15 @@ bool MeshMap::readMap()
   {
     if(!mesh_file.empty() && !mesh_part.empty())
     {
-      // default: mesh_working_file = mesh_file
+      
       if(mesh_working_file == "")
       {
-        mesh_working_file = fs::path(mesh_file).replace_extension(".h5");
+        // default: mesh_working_file = mesh_file filename in this directory
+        mesh_working_file = fs::path(mesh_file).filename().replace_extension(".h5");
       }
 
       if(mesh_working_part == "")
       {
-        std::cout << "BLABLAL: " << mesh_part << std::endl;
         mesh_working_part = mesh_part;
         RCLCPP_INFO_STREAM(node->get_logger(), "Mesh Working Part is empty. Using mesh part es default: '" << mesh_working_part << "'");
       } else {

--- a/mesh_map/src/mesh_map.cpp
+++ b/mesh_map/src/mesh_map.cpp
@@ -110,6 +110,8 @@ MeshMap::MeshMap(tf2_ros::Buffer& tf, const rclcpp::Node::SharedPtr& node)
 
   mesh_file = node->declare_parameter(MESH_MAP_NAMESPACE + ".mesh_file", "");
   mesh_part = node->declare_parameter(MESH_MAP_NAMESPACE + ".mesh_part", "");
+  mesh_working_file = node->declare_parameter(MESH_MAP_NAMESPACE + ".mesh_working_file", "");
+  mesh_working_part = node->declare_parameter(MESH_MAP_NAMESPACE + ".mesh_working_part", "");
   global_frame = node->declare_parameter(MESH_MAP_NAMESPACE + ".global_frame", "map");
 
   RCLCPP_INFO_STREAM(node->get_logger(), "mesh file is set to: " << mesh_file);
@@ -161,7 +163,11 @@ bool MeshMap::readMap()
 
       if(mesh_working_part == "")
       {
-        mesh_working_part == mesh_part;
+        std::cout << "BLABLAL: " << mesh_part << std::endl;
+        mesh_working_part = mesh_part;
+        RCLCPP_INFO_STREAM(node->get_logger(), "Mesh Working Part is empty. Using mesh part es default: '" << mesh_working_part << "'");
+      } else {
+        RCLCPP_INFO_STREAM(node->get_logger(), "Mesh Working Part is *not* empty: '" << mesh_working_part << "'");
       }
       
       if(fs::path(mesh_working_file).extension() != ".h5")
@@ -171,6 +177,7 @@ bool MeshMap::readMap()
       }
       
       // directly work on the input file
+      
       RCLCPP_INFO_STREAM(node->get_logger(), "Connect to \"" << mesh_working_part << "\" from file \"" << mesh_working_file << "\"...");
 
       auto hdf5_mesh_io = std::make_shared<HDF5MeshIO>();
@@ -197,7 +204,7 @@ bool MeshMap::readMap()
           // use another loader
           Assimp::Importer io;
           io.SetPropertyBool(AI_CONFIG_IMPORT_COLLADA_IGNORE_UP_DIRECTION, true);
-          const aiScene* ascene = io.ReadFile(mesh_file, aiProcess_PreTransformVertices | aiProcess_Triangulate | aiProcess_SortByPType);
+          const aiScene* ascene = io.ReadFile(mesh_file, 0);
           if (!ascene)
           {
             RCLCPP_ERROR_STREAM(node->get_logger(), "Error while loading map: " << io.GetErrorString());

--- a/mesh_map/src/mesh_map.cpp
+++ b/mesh_map/src/mesh_map.cpp
@@ -162,11 +162,10 @@ bool MeshMap::readMap()
   {
     if(!mesh_file.empty() && !mesh_part.empty())
     {
-      
       if(mesh_working_file == "")
       {
         // default: mesh_working_file = mesh_file filename in this directory
-        mesh_working_file = fs::path(mesh_file).filename().replace_extension(".h5");
+        mesh_working_file = fs::path(mesh_file).replace_extension(".h5");
       }
 
       if(mesh_working_part == "")

--- a/mesh_map/src/mesh_map.cpp
+++ b/mesh_map/src/mesh_map.cpp
@@ -358,9 +358,6 @@ bool MeshMap::readMap()
     return false;
   }
 
-  // why?
-  sleep(1);
-
   combineVertexCosts(map_stamp);
   publishCostLayers(map_stamp);
 
@@ -465,10 +462,6 @@ bool MeshMap::initLayerPlugins()
     {
       RCLCPP_INFO_STREAM(node->get_logger(), "Computing layer '" << layer_name << "' ...");
       layer_plugin->computeLayer();
-      
-      // RCLCPP_INFO_STREAM(node->get_logger(), "Writing '" << layer_name << "' to file.");
-      // layer_plugin->writeLayer();
-      // RCLCPP_INFO_STREAM(node->get_logger(), "Finished writing '" << layer_name << "' to file.");
     }
 
     lethal_indices[layer_name].insert(layer_plugin->lethals().begin(), layer_plugin->lethals().end());
@@ -495,9 +488,7 @@ void MeshMap::combineVertexCosts(const rclcpp::Time& map_stamp)
     mesh_map::getMinMax(costs, min, max);
     const float norm = max - min;
     const float factor = 1.0;
-    // TODO how to declare param for each plugin? 
-    // Needs to be done after plugins are loaded, which happens when the map gets loaded. Who calls readMap() and when?
-    // const float factor = private_nh.param<float>(MESH_MAP_NAMESPACE + "/" + layer.first + "/factor", 1.0);
+    // TODO: carefully think about this
     const float norm_factor = factor / norm;
     RCLCPP_INFO_STREAM(node->get_logger(), "Layer \"" << layer.first << "\" max value: " << max << " min value: " << min << " norm: " << norm
                                << " factor: " << factor << " norm factor: " << norm_factor);

--- a/mesh_map/src/util.cpp
+++ b/mesh_map/src/util.cpp
@@ -102,13 +102,7 @@ lvr2::MeshBufferPtr extractMeshByName(
 {
   lvr2::MeshBufferPtr mesh;
 
-
   const aiNode* root_node = ascene->mRootNode;
-
-
-  // ascene->mMe
-
-  // const aiNode* mesh_part_node = extractNodeByName(root_node, name);
 
   // bool path_existing = false;
   // transform from mesh to world
@@ -176,8 +170,17 @@ lvr2::MeshBufferPtr extractMeshByName(
   (*mesh)["vertices"] = vertices;
 
   lvr2::Channel<unsigned int> face_indices(amesh->mNumFaces, 3);
+  if(amesh->mNumFaces == 0)
+  {
+    throw std::runtime_error("TRIED TO LOAD 0 TRIANGLES");
+  }
   for(size_t i=0; i<amesh->mNumFaces; i++)
   {
+    if(amesh->mFaces[i].mNumIndices != 3)
+    {
+      RCLCPP_ERROR_STREAM(rclcpp::get_logger("mesh_map/util"), "Mesh contains elements that are no triangles: " << amesh->mFaces[i].mNumIndices);
+      throw std::runtime_error("TRIED TO LOAD NON-TRIANGLES");
+    }
     face_indices[i][0] = amesh->mFaces[i].mIndices[0];
     face_indices[i][1] = amesh->mFaces[i].mIndices[1];
     face_indices[i][2] = amesh->mFaces[i].mIndices[2]; 
@@ -210,7 +213,6 @@ lvr2::MeshBufferPtr extractMeshByName(
     }
     (*mesh)["vertex_colors"] = vertex_colors;
   }
-  
 
   return mesh;
 }

--- a/mesh_map/src/util.cpp
+++ b/mesh_map/src/util.cpp
@@ -44,6 +44,30 @@
 
 namespace mesh_map
 {
+
+lvr2::MeshBufferPtr extractMeshByName(
+  const aiScene* ascene,
+  std::string name)
+{
+  lvr2::MeshBufferPtr mesh;
+
+  // search for mesh part, if there are multiple meshes
+  for (unsigned int meshIdx = 0; meshIdx < ascene->mNumMeshes; meshIdx++)
+  {
+    // const aiMesh* amesh = ascene->mMeshes[meshIdx];
+
+    // // skip non-triangle meshes
+    // if (amesh->mPrimitiveTypes != aiPrimitiveType_TRIANGLE)
+    // {
+    //   RCLCPP_ERROR_STREAM(rclcpp::get_logger("rviz_mesh_tools_plugins"), "Map Display: Mesh " << meshIdx << " is not a triangle mesh! Skipping...");
+    //   continue;
+    // }
+    
+  }
+
+  return mesh;
+}
+
 void getMinMax(const lvr2::VertexMap<float>& costs, float& min, float& max)
 {
   max = std::numeric_limits<float>::min();

--- a/mesh_map/src/util.cpp
+++ b/mesh_map/src/util.cpp
@@ -42,35 +42,54 @@
 #include <tf2/LinearMath/Transform.h>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 
+#include <filesystem>
+
+namespace fs = std::filesystem;
+
 namespace mesh_map
 {
 
-const aiNode* extractNodeByName(
-  const aiNode* node,
-  std::string name)
+// again this function
+std::vector<std::string> split(std::string s, const std::string& delimiter) 
 {
-  if(node == nullptr)
+  std::vector<std::string> tokens;
+  size_t pos = 0;
+  std::string token;
+  while((pos = s.find(delimiter)) != std::string::npos) 
   {
-    return nullptr;
+    token = s.substr(0, pos);
+    tokens.push_back(token);
+    s.erase(0, pos + delimiter.length());
   }
+  tokens.push_back(s);
 
-  if(node->mNumMeshes > 0)
-  {
-    // found something that is a mesh
-    std::string node_name = node->mName.C_Str();
-    if(node_name == name)
-    {
-      // found!
-      return node;
-    }
-  }
-  
+  return tokens;
+}
+
+const aiNode* getChildByName(const aiNode* node, std::string name)
+{
   for(size_t i=0; i<node->mNumChildren; i++)
   {
-    const aiNode* child_node = extractNodeByName(node->mChildren[i], name);
-    if(child_node != nullptr)
+    const std::string child_name = node->mChildren[i]->mName.C_Str();
+    if(child_name == name)
     {
-      return child_node;
+      return node->mChildren[i];
+    }
+  }
+
+  return nullptr;
+}
+
+const aiMesh* getMeshByName(const aiNode* node, aiMesh** meshes, std::string name)
+{
+  for(size_t i=0; i<node->mNumMeshes; i++)
+  {
+    unsigned int mesh_id = node->mMeshes[i];
+    const aiMesh* mesh = meshes[mesh_id];
+    std::string mesh_name = mesh->mName.C_Str();
+    if(mesh_name == name)
+    {
+      return mesh;
     }
   }
 
@@ -85,66 +104,113 @@ lvr2::MeshBufferPtr extractMeshByName(
 
 
   const aiNode* root_node = ascene->mRootNode;
-  const aiNode* mesh_part_node = extractNodeByName(root_node, name);
 
-  if(mesh_part_node)
+
+  // ascene->mMe
+
+  // const aiNode* mesh_part_node = extractNodeByName(root_node, name);
+
+  // bool path_existing = false;
+  // transform from mesh to world
+  aiMatrix4x4 Tmw;
+
+  // (T1 * T2) * T3 * p;
+  std::vector<std::string> path_to_mesh = split(name, "/");
+
+  if(path_to_mesh.size() == 0)
   {
-    if(mesh_part_node->mNumMeshes > 1)
+    return mesh;
+  }
+
+  const aiNode* node_it = root_node;
+  for(size_t i=1; i<path_to_mesh.size()-1; i++)
+  {
+    node_it = getChildByName(node_it, path_to_mesh[i]);
+    
+    if(node_it == nullptr)
     {
-      std::cout << "WARNING: the found mesh part consists of multiple meshes! Using the first one." << std::endl;
+      RCLCPP_WARN_STREAM(rclcpp::get_logger("mesh_map/util"), "'" << path_to_mesh[i] << "' not found in input mesh file!");
+      break;
     }
+    Tmw = Tmw * node_it->mTransformation;
+  }
 
-    unsigned int mesh_id = mesh_part_node->mMeshes[0];
-    
-    const aiMesh* amesh = ascene->mMeshes[mesh_id];
+  if(node_it == nullptr)
+  {
+    RCLCPP_WARN_STREAM(rclcpp::get_logger("mesh_map/util"), "Could not find path '" << name << "' in input mesh file");
+    // early stop
+    return mesh;
+  }
 
-    // fill this
-    mesh = std::make_shared<lvr2::MeshBuffer>();
-    
-    lvr2::Channel<float> vertices(amesh->mNumVertices, 3);
+  if(node_it->mNumMeshes == 0)
+  {
+    RCLCPP_WARN_STREAM(rclcpp::get_logger("mesh_map/util"), "'" << name << "' of input mesh file has not meshes!");
+    // early stop
+    return mesh;
+  }
+
+  const aiMesh* amesh = getMeshByName(node_it, ascene->mMeshes, path_to_mesh.back());
+
+  if(amesh == nullptr)
+  {
+    RCLCPP_WARN_STREAM(rclcpp::get_logger("mesh_map/util"), "Leaf does not exist in mesh file!");
+    return mesh;
+  }
+
+  aiVector3D smw;
+  aiQuaternion Rmw;
+  aiVector3D tmw;
+  Tmw.Decompose(smw, Rmw, tmw);
+
+  // fill this
+  mesh = std::make_shared<lvr2::MeshBuffer>();
+  
+  lvr2::Channel<float> vertices(amesh->mNumVertices, 3);
+  for(size_t i=0; i<amesh->mNumVertices; i++)
+  {
+    aiVector3D avertex = Tmw * amesh->mVertices[i];
+    vertices[i][0] = avertex.x;
+    vertices[i][1] = avertex.y;
+    vertices[i][2] = avertex.z;
+  }
+  (*mesh)["vertices"] = vertices;
+
+  lvr2::Channel<unsigned int> face_indices(amesh->mNumFaces, 3);
+  for(size_t i=0; i<amesh->mNumFaces; i++)
+  {
+    face_indices[i][0] = amesh->mFaces[i].mIndices[0];
+    face_indices[i][1] = amesh->mFaces[i].mIndices[1];
+    face_indices[i][2] = amesh->mFaces[i].mIndices[2]; 
+  }
+  (*mesh)["face_indices"] = face_indices;
+  
+  if(amesh->HasNormals())
+  {
+    // vertex normals
+    lvr2::Channel<float> vertex_normals(amesh->mNumVertices, 3);
     for(size_t i=0; i<amesh->mNumVertices; i++)
     {
-      vertices[i][0] = amesh->mVertices[i].x;
-      vertices[i][1] = amesh->mVertices[i].y;
-      vertices[i][2] = amesh->mVertices[i].z;
+      aiVector3D anormal = Rmw.Rotate(amesh->mNormals[i]);
+      vertex_normals[i][0] = anormal.x;
+      vertex_normals[i][1] = anormal.y;
+      vertex_normals[i][2] = anormal.z;
     }
-    (*mesh)["vertices"] = vertices;
-  
-    lvr2::Channel<unsigned int> face_indices(amesh->mNumFaces, 3);
-    for(size_t i=0; i<amesh->mNumFaces; i++)
-    {
-      face_indices[i][0] = amesh->mFaces[i].mIndices[0];
-      face_indices[i][1] = amesh->mFaces[i].mIndices[1];
-      face_indices[i][2] = amesh->mFaces[i].mIndices[2]; 
-    }
-    (*mesh)["face_indices"] = face_indices;
-    
-    if(amesh->HasNormals())
-    {
-      // vertex normals
-      lvr2::Channel<float> vertex_normals(amesh->mNumVertices, 3);
-      for(size_t i=0; i<amesh->mNumVertices; i++)
-      {
-        vertex_normals[i][0] = amesh->mNormals[i].x;
-        vertex_normals[i][1] = amesh->mNormals[i].y;
-        vertex_normals[i][2] = amesh->mNormals[i].z;
-      }
-      (*mesh)["vertex_normals"] = vertex_normals;
-    }
-
-    if(amesh->HasVertexColors(0))
-    {
-      lvr2::Channel<unsigned char> vertex_colors(amesh->mNumVertices, 4);
-      for(size_t i=0; i<amesh->mNumVertices; i++)
-      {
-        vertex_colors[i][0] = amesh->mColors[0][i].r;
-        vertex_colors[i][1] = amesh->mColors[0][i].g;
-        vertex_colors[i][2] = amesh->mColors[0][i].b;
-        vertex_colors[i][3] = amesh->mColors[0][i].a;
-      }
-      (*mesh)["vertex_colors"] = vertex_colors;
-    }
+    (*mesh)["vertex_normals"] = vertex_normals;
   }
+
+  if(amesh->HasVertexColors(0))
+  {
+    lvr2::Channel<unsigned char> vertex_colors(amesh->mNumVertices, 4);
+    for(size_t i=0; i<amesh->mNumVertices; i++)
+    {
+      vertex_colors[i][0] = amesh->mColors[0][i].r;
+      vertex_colors[i][1] = amesh->mColors[0][i].g;
+      vertex_colors[i][2] = amesh->mColors[0][i].b;
+      vertex_colors[i][3] = amesh->mColors[0][i].a;
+    }
+    (*mesh)["vertex_colors"] = vertex_colors;
+  }
+  
 
   return mesh;
 }

--- a/mesh_map/src/util.cpp
+++ b/mesh_map/src/util.cpp
@@ -104,7 +104,6 @@ lvr2::MeshBufferPtr extractMeshByName(
 
   const aiNode* root_node = ascene->mRootNode;
 
-  // bool path_existing = false;
   // transform from mesh to world
   aiMatrix4x4 Tmw;
 


### PR DESCRIPTION
What I did:
- One can load meshes from common mesh file formats now. It is also possible to load a specific mesh from a whole scene as navigation mesh. One problem remained: Loading the ".dae"s of the mesh nav tutorials gave wrong results. I don't know why. Internally it is divided into an input file and working file. The input file is an arbitrary mesh format (that can be loaded by assimp or HDF5) the working file is always a HDF5. I added a service which can be used to save the current state to the working file.
- The layers are now stored in the HDF5 file by their name. This allows us to integrate many layers of the same type.
- I quickly tested some of the tutorials and everything worked out fine. So it should be downwards compatible.
- Some bug fixes.