### PR TITLE
fix mesh map stamp when using sim time

### DIFF
--- a/mesh_map/src/mesh_map.cpp
+++ b/mesh_map/src/mesh_map.cpp
@@ -265,7 +265,17 @@ bool MeshMap::readMap()
     }
   }
 
-  const rclcpp::Time map_stamp = node->now();
+  rclcpp::Time map_stamp = node->now();
+  // Workaround: Avoid publishing a map with zero timestamp.
+  // This can occur when using sim time and the node using mesh map starts to quickly,
+  // before whatever should publish /clock (e.g. gazebo) is ready.
+  // A map with timestamp zero will not get displayed in rviz.
+  // Generally, a zero timestamp is currently considered be an error / unintialized stamp.
+  // Issue https://github.com/ros2/rclcpp/issues/2025 might want to change that, though.
+  while (map_stamp.nanoseconds() == 0) { // TODO check whether time is zero
+    sleep(0.5);
+    map_stamp = node->now();
+  }
   mesh_geometry_pub->publish(mesh_msgs_conversions::toMeshGeometryStamped<float>(*mesh_ptr, global_frame, uuid_str, vertex_normals, map_stamp));
   publishVertexColors(map_stamp);
 


### PR DESCRIPTION
Workaround that fixes mesh map display in rviz.

Maybe we could do a cleaner check against uninitialized time in the future, when there is another way of handling unintialized Time. See https://github.com/ros2/rclcpp/issues/2025.

Without this workaround, the mesh map is published with stamp zero. The tf message filter in `mesh_tool`'s MeshDisplay rviz plugin will drop the message. This is probably due to the [design docs](http://design.ros2.org/articles/clock_and_time.html) stating that `A time value of zero should be considered an error meaning that time is uninitialized`.

Here are some more details:
#### Setup
I have
- a (move base flex) node that publishes a (static) mesh map on startup. It uses `sim_time`.
- something that publishes `./clock`, here: gazebo
- rviz with a plugin for visualizing the map. The plugin is a display that uses `tf2_ros::RVizMessageFilter` to ensure the map is transformable into the right frame.

#### Problem
After starting up the system, the map is often not being displayed in rviz.

#### Analysis
The published map's `header.stamp` is zero.
I am relatively sure that this causes `tf2_ros::RVizMessageFilter` to drop the msg, hence, no map is visible.

`header.stamp` is set via `node->now()`, which is zero, because gazebo did not start up fast enough. So I end up using uninitialized time.

#### Workaround
My workaround consists of a sleep-loop that waits until `node->now()` is not zero anymore, before publishing the map.