### PR TITLE
Fix nullptr dereference in mesh_map::readMap() and remove dependency on mesh_client

### DIFF
--- a/mesh_map/src/mesh_map.cpp
+++ b/mesh_map/src/mesh_map.cpp
@@ -284,10 +284,9 @@ bool MeshMap::readMap()
   hdf5_mesh_input->setMeshName(mesh_working_part);
   lvr2::MeshBufferPtr mesh_buffer = hdf5_mesh_input->MeshIO::load(mesh_working_part);
 
-  RCLCPP_DEBUG_STREAM(node->get_logger(), "Convert buffer to HEM: \n" << *mesh_buffer);
-
   if(mesh_buffer)
   {
+    RCLCPP_DEBUG_STREAM(node->get_logger(), "Convert buffer to HEM: \n" << *mesh_buffer);
     RCLCPP_DEBUG_STREAM(node->get_logger(), "Creating mesh of type '" << hem_impl_ << "'");
     mesh_ptr = createHemByName(hem_impl_, mesh_buffer);
     RCLCPP_INFO_STREAM(node->get_logger(), "The mesh of type '" << hem_impl_ <<  "' has been loaded successfully with " 

--- a/mesh_navigation/package.xml
+++ b/mesh_navigation/package.xml
@@ -10,7 +10,6 @@
 
     <exec_depend>mbf_mesh_core</exec_depend>
     <exec_depend>mbf_mesh_nav</exec_depend>
-    <exec_depend>mesh_client</exec_depend>
     <exec_depend>mesh_controller</exec_depend>
     <exec_depend>mesh_layers</exec_depend>
     <exec_depend>mesh_map</exec_depend>


### PR DESCRIPTION
This pr fixes the following two bugs:
- The `MeshMap` would dereference a null pointer if no map could be loaded.
- The `mesh_navigation` package had an `<exec_depend>` tag on the removed `mesh_client` package which prevents rosdep from working due to an unresolved package.